### PR TITLE
[Feat] 캘린더 탭 UI 구현

### DIFF
--- a/CommonPlant/CommonPlant.xcodeproj/project.pbxproj
+++ b/CommonPlant/CommonPlant.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		C0C104E72A56DD5F00945BD6 /* UIFont+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C104E62A56DD5F00945BD6 /* UIFont+Extension.swift */; };
 		C0E2700D2B981E93006492B0 /* CalendarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E2700C2B981E93006492B0 /* CalendarViewModel.swift */; };
 		C0E270102B982D45006492B0 /* CalendarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E2700F2B982D45006492B0 /* CalendarViewController.swift */; };
+		C0E270142B984108006492B0 /* CalendarCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E270132B984108006492B0 /* CalendarCollectionViewCell.swift */; };
 		C0EE4A012B182D4000592185 /* CommonAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EE4A002B182D4000592185 /* CommonAlertView.swift */; };
 		F91E47802A53E3C9008E07A9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91E477F2A53E3C9008E07A9 /* AppDelegate.swift */; };
 		F91E47822A53E3C9008E07A9 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91E47812A53E3C9008E07A9 /* SceneDelegate.swift */; };
@@ -132,6 +133,7 @@
 		C0C104E62A56DD5F00945BD6 /* UIFont+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
 		C0E2700C2B981E93006492B0 /* CalendarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewModel.swift; sourceTree = "<group>"; };
 		C0E2700F2B982D45006492B0 /* CalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewController.swift; sourceTree = "<group>"; };
+		C0E270132B984108006492B0 /* CalendarCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarCollectionViewCell.swift; sourceTree = "<group>"; };
 		C0EE4A002B182D4000592185 /* CommonAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonAlertView.swift; sourceTree = "<group>"; };
 		F91E477C2A53E3C9008E07A9 /* CommonPlant.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CommonPlant.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F91E477F2A53E3C9008E07A9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -353,9 +355,26 @@
 		C0E2700E2B982D27006492B0 /* View */ = {
 			isa = PBXGroup;
 			children = (
-				C0E2700F2B982D45006492B0 /* CalendarViewController.swift */,
+				C0E270122B9840EF006492B0 /* Controller */,
+				C0E270112B9840E9006492B0 /* Cell */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		C0E270112B9840E9006492B0 /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				C0E270132B984108006492B0 /* CalendarCollectionViewCell.swift */,
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
+		C0E270122B9840EF006492B0 /* Controller */ = {
+			isa = PBXGroup;
+			children = (
+				C0E2700F2B982D45006492B0 /* CalendarViewController.swift */,
+			);
+			path = Controller;
 			sourceTree = "<group>";
 		};
 		F91E47732A53E3C8008E07A9 = {
@@ -680,6 +699,7 @@
 				C007F6452B5F712200CD6252 /* AddPlantSecondViewModel.swift in Sources */,
 				C02322B82A6AC0D6004D78CC /* EditUserInfoViewModel.swift in Sources */,
 				F91E47AC2A569666008E07A9 /* empty.swift in Sources */,
+				C0E270142B984108006492B0 /* CalendarCollectionViewCell.swift in Sources */,
 				F9447DAD2A78E52200903C28 /* PopularSearchCollectionViewCell.swift in Sources */,
 				F91E47B42A569698008E07A9 /* empty4.swift in Sources */,
 				C059A2712A5A4B54005C0449 /* EditUserInfoViewController.swift in Sources */,

--- a/CommonPlant/CommonPlant.xcodeproj/project.pbxproj
+++ b/CommonPlant/CommonPlant.xcodeproj/project.pbxproj
@@ -929,7 +929,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -967,7 +967,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/CommonPlant/CommonPlant.xcodeproj/project.pbxproj
+++ b/CommonPlant/CommonPlant.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		C0E2700D2B981E93006492B0 /* CalendarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E2700C2B981E93006492B0 /* CalendarViewModel.swift */; };
 		C0E270102B982D45006492B0 /* CalendarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E2700F2B982D45006492B0 /* CalendarViewController.swift */; };
 		C0E270142B984108006492B0 /* CalendarCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E270132B984108006492B0 /* CalendarCollectionViewCell.swift */; };
+		C0E270162B9849A1006492B0 /* CalendarPlaceCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E270152B9849A1006492B0 /* CalendarPlaceCollectionViewCell.swift */; };
 		C0EE4A012B182D4000592185 /* CommonAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EE4A002B182D4000592185 /* CommonAlertView.swift */; };
 		F91E47802A53E3C9008E07A9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91E477F2A53E3C9008E07A9 /* AppDelegate.swift */; };
 		F91E47822A53E3C9008E07A9 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91E47812A53E3C9008E07A9 /* SceneDelegate.swift */; };
@@ -134,6 +135,7 @@
 		C0E2700C2B981E93006492B0 /* CalendarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewModel.swift; sourceTree = "<group>"; };
 		C0E2700F2B982D45006492B0 /* CalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewController.swift; sourceTree = "<group>"; };
 		C0E270132B984108006492B0 /* CalendarCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarCollectionViewCell.swift; sourceTree = "<group>"; };
+		C0E270152B9849A1006492B0 /* CalendarPlaceCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarPlaceCollectionViewCell.swift; sourceTree = "<group>"; };
 		C0EE4A002B182D4000592185 /* CommonAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonAlertView.swift; sourceTree = "<group>"; };
 		F91E477C2A53E3C9008E07A9 /* CommonPlant.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CommonPlant.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F91E477F2A53E3C9008E07A9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -365,6 +367,7 @@
 			isa = PBXGroup;
 			children = (
 				C0E270132B984108006492B0 /* CalendarCollectionViewCell.swift */,
+				C0E270152B9849A1006492B0 /* CalendarPlaceCollectionViewCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -699,6 +702,7 @@
 				C007F6452B5F712200CD6252 /* AddPlantSecondViewModel.swift in Sources */,
 				C02322B82A6AC0D6004D78CC /* EditUserInfoViewModel.swift in Sources */,
 				F91E47AC2A569666008E07A9 /* empty.swift in Sources */,
+				C0E270162B9849A1006492B0 /* CalendarPlaceCollectionViewCell.swift in Sources */,
 				C0E270142B984108006492B0 /* CalendarCollectionViewCell.swift in Sources */,
 				F9447DAD2A78E52200903C28 /* PopularSearchCollectionViewCell.swift in Sources */,
 				F91E47B42A569698008E07A9 /* empty4.swift in Sources */,

--- a/CommonPlant/CommonPlant.xcodeproj/project.pbxproj
+++ b/CommonPlant/CommonPlant.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		C0E270142B984108006492B0 /* CalendarCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E270132B984108006492B0 /* CalendarCollectionViewCell.swift */; };
 		C0E270162B9849A1006492B0 /* CalendarPlaceCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E270152B9849A1006492B0 /* CalendarPlaceCollectionViewCell.swift */; };
 		C0E270182B984C91006492B0 /* CalendarPlantCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E270172B984C91006492B0 /* CalendarPlantCollectionViewCell.swift */; };
+		C0E2701A2B98507F006492B0 /* CalendarMemoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E270192B98507F006492B0 /* CalendarMemoCollectionViewCell.swift */; };
 		C0EE4A012B182D4000592185 /* CommonAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EE4A002B182D4000592185 /* CommonAlertView.swift */; };
 		F91E47802A53E3C9008E07A9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91E477F2A53E3C9008E07A9 /* AppDelegate.swift */; };
 		F91E47822A53E3C9008E07A9 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91E47812A53E3C9008E07A9 /* SceneDelegate.swift */; };
@@ -138,6 +139,7 @@
 		C0E270132B984108006492B0 /* CalendarCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarCollectionViewCell.swift; sourceTree = "<group>"; };
 		C0E270152B9849A1006492B0 /* CalendarPlaceCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarPlaceCollectionViewCell.swift; sourceTree = "<group>"; };
 		C0E270172B984C91006492B0 /* CalendarPlantCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarPlantCollectionViewCell.swift; sourceTree = "<group>"; };
+		C0E270192B98507F006492B0 /* CalendarMemoCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarMemoCollectionViewCell.swift; sourceTree = "<group>"; };
 		C0EE4A002B182D4000592185 /* CommonAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonAlertView.swift; sourceTree = "<group>"; };
 		F91E477C2A53E3C9008E07A9 /* CommonPlant.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CommonPlant.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F91E477F2A53E3C9008E07A9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -371,6 +373,7 @@
 				C0E270132B984108006492B0 /* CalendarCollectionViewCell.swift */,
 				C0E270152B9849A1006492B0 /* CalendarPlaceCollectionViewCell.swift */,
 				C0E270172B984C91006492B0 /* CalendarPlantCollectionViewCell.swift */,
+				C0E270192B98507F006492B0 /* CalendarMemoCollectionViewCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -749,6 +752,7 @@
 				C07DF87E2A597A8600CDC5CC /* WithdrwalViewController.swift in Sources */,
 				C027A0952A909CDC009289E9 /* ImagePickerCollectionViewCell.swift in Sources */,
 				C044E5AA2A66C1A800A8B3C6 /* SettingViewModel.swift in Sources */,
+				C0E2701A2B98507F006492B0 /* CalendarMemoCollectionViewCell.swift in Sources */,
 				C0A0D4E02A73EAD800426514 /* PrivacyViewController.swift in Sources */,
 				F91E47AA2A569128008E07A9 /* UIColor+Extension.swift in Sources */,
 				C073EBE12B736B6F006980BB /* PlaceCollectionViewCell.swift in Sources */,

--- a/CommonPlant/CommonPlant.xcodeproj/project.pbxproj
+++ b/CommonPlant/CommonPlant.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		C0E270102B982D45006492B0 /* CalendarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E2700F2B982D45006492B0 /* CalendarViewController.swift */; };
 		C0E270142B984108006492B0 /* CalendarCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E270132B984108006492B0 /* CalendarCollectionViewCell.swift */; };
 		C0E270162B9849A1006492B0 /* CalendarPlaceCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E270152B9849A1006492B0 /* CalendarPlaceCollectionViewCell.swift */; };
+		C0E270182B984C91006492B0 /* CalendarPlantCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E270172B984C91006492B0 /* CalendarPlantCollectionViewCell.swift */; };
 		C0EE4A012B182D4000592185 /* CommonAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EE4A002B182D4000592185 /* CommonAlertView.swift */; };
 		F91E47802A53E3C9008E07A9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91E477F2A53E3C9008E07A9 /* AppDelegate.swift */; };
 		F91E47822A53E3C9008E07A9 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91E47812A53E3C9008E07A9 /* SceneDelegate.swift */; };
@@ -136,6 +137,7 @@
 		C0E2700F2B982D45006492B0 /* CalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewController.swift; sourceTree = "<group>"; };
 		C0E270132B984108006492B0 /* CalendarCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarCollectionViewCell.swift; sourceTree = "<group>"; };
 		C0E270152B9849A1006492B0 /* CalendarPlaceCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarPlaceCollectionViewCell.swift; sourceTree = "<group>"; };
+		C0E270172B984C91006492B0 /* CalendarPlantCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarPlantCollectionViewCell.swift; sourceTree = "<group>"; };
 		C0EE4A002B182D4000592185 /* CommonAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonAlertView.swift; sourceTree = "<group>"; };
 		F91E477C2A53E3C9008E07A9 /* CommonPlant.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CommonPlant.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F91E477F2A53E3C9008E07A9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -368,6 +370,7 @@
 			children = (
 				C0E270132B984108006492B0 /* CalendarCollectionViewCell.swift */,
 				C0E270152B9849A1006492B0 /* CalendarPlaceCollectionViewCell.swift */,
+				C0E270172B984C91006492B0 /* CalendarPlantCollectionViewCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -684,6 +687,7 @@
 				C0B1BDED2A9E23F100DD7E04 /* MemoCollectionViewCell.swift in Sources */,
 				C0EE4A012B182D4000592185 /* CommonAlertView.swift in Sources */,
 				F9D0CCA42A583442006D688C /* MainViewController.swift in Sources */,
+				C0E270182B984C91006492B0 /* CalendarPlantCollectionViewCell.swift in Sources */,
 				F9447DA32A76CA3100903C28 /* (null) in Sources */,
 				F91E47B22A56968E008E07A9 /* empty3.swift in Sources */,
 				C039A8672B79E5CD00673CCC /* EditPlantViewController.swift in Sources */,

--- a/CommonPlant/CommonPlant.xcodeproj/project.pbxproj
+++ b/CommonPlant/CommonPlant.xcodeproj/project.pbxproj
@@ -906,8 +906,8 @@
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "프로필 사진, 장소, 식물을 등록하거나, 식물에 관한 메모를 등록할 때 사용합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -944,8 +944,8 @@
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "프로필 사진, 장소, 식물을 등록하거나, 식물에 관한 메모를 등록할 때 사용합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/CommonPlant/CommonPlant.xcodeproj/project.pbxproj
+++ b/CommonPlant/CommonPlant.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		C0B1BDED2A9E23F100DD7E04 /* MemoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B1BDEC2A9E23F100DD7E04 /* MemoCollectionViewCell.swift */; };
 		C0BDF2E52B1EFD7A002C7FD7 /* EditMemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0BDF2E42B1EFD7A002C7FD7 /* EditMemoViewController.swift */; };
 		C0C104E72A56DD5F00945BD6 /* UIFont+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C104E62A56DD5F00945BD6 /* UIFont+Extension.swift */; };
+		C0E2700D2B981E93006492B0 /* CalendarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E2700C2B981E93006492B0 /* CalendarViewModel.swift */; };
 		C0EE4A012B182D4000592185 /* CommonAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EE4A002B182D4000592185 /* CommonAlertView.swift */; };
 		F91E47802A53E3C9008E07A9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91E477F2A53E3C9008E07A9 /* AppDelegate.swift */; };
 		F91E47822A53E3C9008E07A9 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91E47812A53E3C9008E07A9 /* SceneDelegate.swift */; };
@@ -128,6 +129,7 @@
 		C0B1BDEC2A9E23F100DD7E04 /* MemoCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoCollectionViewCell.swift; sourceTree = "<group>"; };
 		C0BDF2E42B1EFD7A002C7FD7 /* EditMemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditMemoViewController.swift; sourceTree = "<group>"; };
 		C0C104E62A56DD5F00945BD6 /* UIFont+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
+		C0E2700C2B981E93006492B0 /* CalendarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewModel.swift; sourceTree = "<group>"; };
 		C0EE4A002B182D4000592185 /* CommonAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonAlertView.swift; sourceTree = "<group>"; };
 		F91E477C2A53E3C9008E07A9 /* CommonPlant.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CommonPlant.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F91E477F2A53E3C9008E07A9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -329,6 +331,22 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		C0E270072B9713AC006492B0 /* Calendar */ = {
+			isa = PBXGroup;
+			children = (
+				C0E2700B2B9713DD006492B0 /* ViewModel */,
+			);
+			path = Calendar;
+			sourceTree = "<group>";
+		};
+		C0E2700B2B9713DD006492B0 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				C0E2700C2B981E93006492B0 /* CalendarViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
 		F91E47732A53E3C8008E07A9 = {
 			isa = PBXGroup;
 			children = (
@@ -399,6 +417,7 @@
 		F91E47A12A53EFAC008E07A9 /* Screen */ = {
 			isa = PBXGroup;
 			children = (
+				C0E270072B9713AC006492B0 /* Calendar */,
 				F91E478A2A53E3CA008E07A9 /* LaunchScreen.storyboard */,
 				C0A6DCE52A97883D001A2E11 /* MyPlant */,
 				C027A0882A909BB0009289E9 /* ImagePicker */,
@@ -660,6 +679,7 @@
 				F93404042A8207B000F0267B /* SearchResultViewModel.swift in Sources */,
 				C073EBE32B738F9E006980BB /* DatePickerCollectionViewCell.swift in Sources */,
 				F93404022A81F9F400F0267B /* SearchResultTableViewCell.swift in Sources */,
+				C0E2700D2B981E93006492B0 /* CalendarViewModel.swift in Sources */,
 				C0A0D4DD2A73E96800426514 /* SignUpViewModel.swift in Sources */,
 				C069D2B72AC0469A00A62E04 /* CommonMenuView.swift in Sources */,
 				C007F6472B62562200CD6252 /* AddPlantSecondViewController.swift in Sources */,

--- a/CommonPlant/CommonPlant.xcodeproj/project.pbxproj
+++ b/CommonPlant/CommonPlant.xcodeproj/project.pbxproj
@@ -59,6 +59,9 @@
 		C0E270162B9849A1006492B0 /* CalendarPlaceCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E270152B9849A1006492B0 /* CalendarPlaceCollectionViewCell.swift */; };
 		C0E270182B984C91006492B0 /* CalendarPlantCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E270172B984C91006492B0 /* CalendarPlantCollectionViewCell.swift */; };
 		C0E2701A2B98507F006492B0 /* CalendarMemoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E270192B98507F006492B0 /* CalendarMemoCollectionViewCell.swift */; };
+		C0E2701D2B999BAE006492B0 /* CalendarPlant.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E2701C2B999BAE006492B0 /* CalendarPlant.swift */; };
+		C0E2701F2B999C06006492B0 /* CalendarPlace.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E2701E2B999C06006492B0 /* CalendarPlace.swift */; };
+		C0E270212B999C37006492B0 /* CalendarMemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E270202B999C37006492B0 /* CalendarMemo.swift */; };
 		C0EE4A012B182D4000592185 /* CommonAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EE4A002B182D4000592185 /* CommonAlertView.swift */; };
 		F91E47802A53E3C9008E07A9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91E477F2A53E3C9008E07A9 /* AppDelegate.swift */; };
 		F91E47822A53E3C9008E07A9 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91E47812A53E3C9008E07A9 /* SceneDelegate.swift */; };
@@ -140,6 +143,9 @@
 		C0E270152B9849A1006492B0 /* CalendarPlaceCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarPlaceCollectionViewCell.swift; sourceTree = "<group>"; };
 		C0E270172B984C91006492B0 /* CalendarPlantCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarPlantCollectionViewCell.swift; sourceTree = "<group>"; };
 		C0E270192B98507F006492B0 /* CalendarMemoCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarMemoCollectionViewCell.swift; sourceTree = "<group>"; };
+		C0E2701C2B999BAE006492B0 /* CalendarPlant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarPlant.swift; sourceTree = "<group>"; };
+		C0E2701E2B999C06006492B0 /* CalendarPlace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarPlace.swift; sourceTree = "<group>"; };
+		C0E270202B999C37006492B0 /* CalendarMemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarMemo.swift; sourceTree = "<group>"; };
 		C0EE4A002B182D4000592185 /* CommonAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonAlertView.swift; sourceTree = "<group>"; };
 		F91E477C2A53E3C9008E07A9 /* CommonPlant.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CommonPlant.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F91E477F2A53E3C9008E07A9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -344,6 +350,7 @@
 		C0E270072B9713AC006492B0 /* Calendar */ = {
 			isa = PBXGroup;
 			children = (
+				C0E2701B2B999B6D006492B0 /* Model */,
 				C0E2700B2B9713DD006492B0 /* ViewModel */,
 				C0E2700E2B982D27006492B0 /* View */,
 			);
@@ -384,6 +391,16 @@
 				C0E2700F2B982D45006492B0 /* CalendarViewController.swift */,
 			);
 			path = Controller;
+			sourceTree = "<group>";
+		};
+		C0E2701B2B999B6D006492B0 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				C0E2701C2B999BAE006492B0 /* CalendarPlant.swift */,
+				C0E2701E2B999C06006492B0 /* CalendarPlace.swift */,
+				C0E270202B999C37006492B0 /* CalendarMemo.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		F91E47732A53E3C8008E07A9 = {
@@ -695,6 +712,7 @@
 				F91E47B22A56968E008E07A9 /* empty3.swift in Sources */,
 				C039A8672B79E5CD00673CCC /* EditPlantViewController.swift in Sources */,
 				C0A0D4E22A73EAE200426514 /* PrivacyViewModel.swift in Sources */,
+				C0E2701D2B999BAE006492B0 /* CalendarPlant.swift in Sources */,
 				F9D0CCA22A583432006D688C /* MainTabBarController.swift in Sources */,
 				C0B1BDEB2A9E21F200DD7E04 /* MemoListViewController.swift in Sources */,
 				C0B1BDE72A9E1ECA00DD7E04 /* MemoViewModel.swift in Sources */,
@@ -702,6 +720,7 @@
 				F91E47B42A569698008E07A9 /* empty4.swift in Sources */,
 				F9A1FB252A664F4300F346DE /* MainViewModel.swift in Sources */,
 				C0A0D4DE2A73E96800426514 /* LogInViewModel.swift in Sources */,
+				C0E270212B999C37006492B0 /* CalendarMemo.swift in Sources */,
 				F9A1FB292A67B03400F346DE /* MainModel.swift in Sources */,
 				F93404002A81F89300F0267B /* SearchResultViewController.swift in Sources */,
 				C07DF8842A59844400CDC5CC /* UIView+Extension.swift in Sources */,
@@ -729,6 +748,7 @@
 				C085BFBF2A71686E00188C02 /* SignUpViewController.swift in Sources */,
 				C02322B62A6AB6BE004D78CC /* WithdrwalViewModel.swift in Sources */,
 				F9447DAB2A78D26F00903C28 /* PoplularSearchModel.swift in Sources */,
+				C0E2701F2B999C06006492B0 /* CalendarPlace.swift in Sources */,
 				C0E270102B982D45006492B0 /* CalendarViewController.swift in Sources */,
 				C005D3642A9B3870004CD53F /* MemoCardCollectionViewCell.swift in Sources */,
 				C007F63B2B59198E00CD6252 /* AddPlantFirstViewController.swift in Sources */,

--- a/CommonPlant/CommonPlant.xcodeproj/project.pbxproj
+++ b/CommonPlant/CommonPlant.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		C0BDF2E52B1EFD7A002C7FD7 /* EditMemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0BDF2E42B1EFD7A002C7FD7 /* EditMemoViewController.swift */; };
 		C0C104E72A56DD5F00945BD6 /* UIFont+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C104E62A56DD5F00945BD6 /* UIFont+Extension.swift */; };
 		C0E2700D2B981E93006492B0 /* CalendarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E2700C2B981E93006492B0 /* CalendarViewModel.swift */; };
+		C0E270102B982D45006492B0 /* CalendarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E2700F2B982D45006492B0 /* CalendarViewController.swift */; };
 		C0EE4A012B182D4000592185 /* CommonAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EE4A002B182D4000592185 /* CommonAlertView.swift */; };
 		F91E47802A53E3C9008E07A9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91E477F2A53E3C9008E07A9 /* AppDelegate.swift */; };
 		F91E47822A53E3C9008E07A9 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91E47812A53E3C9008E07A9 /* SceneDelegate.swift */; };
@@ -130,6 +131,7 @@
 		C0BDF2E42B1EFD7A002C7FD7 /* EditMemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditMemoViewController.swift; sourceTree = "<group>"; };
 		C0C104E62A56DD5F00945BD6 /* UIFont+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
 		C0E2700C2B981E93006492B0 /* CalendarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewModel.swift; sourceTree = "<group>"; };
+		C0E2700F2B982D45006492B0 /* CalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewController.swift; sourceTree = "<group>"; };
 		C0EE4A002B182D4000592185 /* CommonAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonAlertView.swift; sourceTree = "<group>"; };
 		F91E477C2A53E3C9008E07A9 /* CommonPlant.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CommonPlant.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F91E477F2A53E3C9008E07A9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -335,6 +337,7 @@
 			isa = PBXGroup;
 			children = (
 				C0E2700B2B9713DD006492B0 /* ViewModel */,
+				C0E2700E2B982D27006492B0 /* View */,
 			);
 			path = Calendar;
 			sourceTree = "<group>";
@@ -345,6 +348,14 @@
 				C0E2700C2B981E93006492B0 /* CalendarViewModel.swift */,
 			);
 			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		C0E2700E2B982D27006492B0 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				C0E2700F2B982D45006492B0 /* CalendarViewController.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 		F91E47732A53E3C8008E07A9 = {
@@ -687,6 +698,7 @@
 				C085BFBF2A71686E00188C02 /* SignUpViewController.swift in Sources */,
 				C02322B62A6AB6BE004D78CC /* WithdrwalViewModel.swift in Sources */,
 				F9447DAB2A78D26F00903C28 /* PoplularSearchModel.swift in Sources */,
+				C0E270102B982D45006492B0 /* CalendarViewController.swift in Sources */,
 				C005D3642A9B3870004CD53F /* MemoCardCollectionViewCell.swift in Sources */,
 				C007F63B2B59198E00CD6252 /* AddPlantFirstViewController.swift in Sources */,
 				C07DF86D2A5943FA00CDC5CC /* MyPageViewController.swift in Sources */,

--- a/CommonPlant/CommonPlant/Global/Extensions/UIColor+Extension.swift
+++ b/CommonPlant/CommonPlant/Global/Extensions/UIColor+Extension.swift
@@ -18,6 +18,7 @@ extension UIColor {
     // Secondary Color
     class var aquaBlue: UIColor? { return UIColor(named: "Aqua")}
     class var sunflowerYellow: UIColor? { return UIColor(named: "Sunflower")}
+    class var mauvePurple: UIColor? { return UIColor(named: "Mauve")}
     
     // Gray Scale
     class var gray1: UIColor? { return UIColor(named: "Gray1") }
@@ -31,4 +32,5 @@ extension UIColor {
     class var activeBlue: UIColor? { return UIColor(named: "ActiveBlue") }
     class var activeRed: UIColor? { return UIColor(named: "ActiveRed") }
     class var activeOrange: UIColor? { return UIColor(named: "ActiveOrange")}
+    class var activePurple: UIColor? { return UIColor(named: "ActivePurple")}
 }

--- a/CommonPlant/CommonPlant/Global/Extensions/UIColor+Extension.swift
+++ b/CommonPlant/CommonPlant/Global/Extensions/UIColor+Extension.swift
@@ -15,6 +15,10 @@ extension UIColor {
     class var seaGreenDark3: UIColor? { return UIColor(named: "SeaGreenDark3") }
     class var seaGreenLight: UIColor? { return UIColor(named: "SeaGreenLight") }
     
+    // Secondary Color
+    class var aquaBlue: UIColor? { return UIColor(named: "Aqua")}
+    class var sunflowerYellow: UIColor? { return UIColor(named: "Sunflower")}
+    
     // Gray Scale
     class var gray1: UIColor? { return UIColor(named: "Gray1") }
     class var gray2: UIColor? { return UIColor(named: "Gray2") }
@@ -26,4 +30,5 @@ extension UIColor {
     // Active Color
     class var activeBlue: UIColor? { return UIColor(named: "ActiveBlue") }
     class var activeRed: UIColor? { return UIColor(named: "ActiveRed") }
+    class var activeOrange: UIColor? { return UIColor(named: "ActiveOrange")}
 }

--- a/CommonPlant/CommonPlant/Global/Extensions/UIView+Extension.swift
+++ b/CommonPlant/CommonPlant/Global/Extensions/UIView+Extension.swift
@@ -13,12 +13,12 @@ extension UIView {
         clipsToBounds = true
     }
     
-    func makeShadow() {
+    func makeShadow(cornerRadius: CGFloat) {
+        layer.shadowPath = UIBezierPath(roundedRect: self.bounds, cornerRadius: cornerRadius).cgPath
         layer.shadowColor = UIColor.gray5?.cgColor
-        layer.shadowOffset = CGSize(width: 0, height: 1)
+        layer.shadowOffset = CGSize(width: 0, height: 0)
         layer.shadowOpacity = 0.25
         layer.shadowRadius = 2
-        layer.cornerRadius = 16
     }
     
     func makeGradation() {

--- a/CommonPlant/CommonPlant/Resource/Assets.xcassets/Color Set/ActiveOrange.colorset/Contents.json
+++ b/CommonPlant/CommonPlant/Resource/Assets.xcassets/Color Set/ActiveOrange.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.561",
+          "red" : "0.937"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.561",
+          "red" : "0.937"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/CommonPlant/CommonPlant/Resource/Assets.xcassets/Color Set/ActivePurple.colorset/Contents.json
+++ b/CommonPlant/CommonPlant/Resource/Assets.xcassets/Color Set/ActivePurple.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.910",
+          "green" : "0.541",
+          "red" : "0.812"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/CommonPlant/CommonPlant/Resource/Assets.xcassets/Color Set/Aqua.colorset/Contents.json
+++ b/CommonPlant/CommonPlant/Resource/Assets.xcassets/Color Set/Aqua.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.839",
+          "red" : "0.153"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.839",
+          "red" : "0.153"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/CommonPlant/CommonPlant/Resource/Assets.xcassets/Color Set/Mauve.colorset/Contents.json
+++ b/CommonPlant/CommonPlant/Resource/Assets.xcassets/Color Set/Mauve.colorset/Contents.json
@@ -1,0 +1,23 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.592",
+          "red" : "0.894"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "localizable" : true
+  }
+}

--- a/CommonPlant/CommonPlant/Resource/Assets.xcassets/Color Set/Sunflower.colorset/Contents.json
+++ b/CommonPlant/CommonPlant/Resource/Assets.xcassets/Color Set/Sunflower.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.259",
+          "green" : "0.749",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.259",
+          "green" : "0.749",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/CommonPlant/CommonPlant/Resource/Supports/SceneDelegate.swift
+++ b/CommonPlant/CommonPlant/Resource/Supports/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         // 뷰 확인하기
         window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = UINavigationController(rootViewController: EditPlantViewController())
+        window?.rootViewController = MainTabBarController()
         window?.makeKeyAndVisible()
     }
     

--- a/CommonPlant/CommonPlant/Screen/Calendar/Model/CalendarMemo.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/Model/CalendarMemo.swift
@@ -1,0 +1,14 @@
+//
+//  CalendarMemo.swift
+//  CommonPlant
+//
+//  Created by 아라 on 3/7/24.
+//
+
+import Foundation
+
+struct CalendarMemo {
+    let userProfileImageString: String
+    let userNickname: String
+    let content: String
+}

--- a/CommonPlant/CommonPlant/Screen/Calendar/Model/CalendarPlace.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/Model/CalendarPlace.swift
@@ -1,0 +1,12 @@
+//
+//  CalendarPlace.swift
+//  CommonPlant
+//
+//  Created by 아라 on 3/7/24.
+//
+
+import Foundation
+
+struct CalendarPlace {
+    let title: String
+}

--- a/CommonPlant/CommonPlant/Screen/Calendar/Model/CalendarPlant.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/Model/CalendarPlant.swift
@@ -1,0 +1,14 @@
+//
+//  CalendarPlant.swift
+//  CommonPlant
+//
+//  Created by 아라 on 3/7/24.
+//
+
+import Foundation
+
+struct CalendarPlant {
+    let imageString: String
+    let nickname: String
+    let name: String
+}

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/CalendarViewController.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/CalendarViewController.swift
@@ -1,0 +1,156 @@
+//
+//  CalendarViewController.swift
+//  CommonPlant
+//
+//  Created by 아라 on 3/6/24.
+//
+
+import UIKit
+
+class CalendarViewController: UIViewController {
+    // MARK: - UI Components
+    private let scrollView: UIView = {
+        let view = UIScrollView()
+        view.showsVerticalScrollIndicator = false
+        return view
+    }()
+    private let contentView = UIView()
+    private let calendarView: UIView = {
+        let view = UIView()
+        view.isHidden = true
+        return view
+    }()
+    private let selectedMonthLabel: UILabel = {
+        let label = UILabel()
+        label.font = .bodyB1
+        label.textColor = .gray6
+        return label
+    }()
+    private let wholeMonthButton: UIButton = {
+        let button = UIButton()
+        var config = UIButton.Configuration.plain()
+        config.image = UIImage(named: "NextMonth")
+        config.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 12, bottom: 12, trailing: 12)
+        button.configuration = config
+        return button
+    }()
+    private let previousButton: UIButton = {
+        let button = UIButton()
+        var config = UIButton.Configuration.plain()
+        config.image = UIImage(named: "PreMonth")
+        config.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 12, bottom: 12, trailing: 12)
+        button.configuration = config
+        return button
+    }()
+    private let nextButton: UIButton = {
+        let button = UIButton()
+        var config = UIButton.Configuration.plain()
+        config.image = UIImage(named: "NextMonth")
+        config.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 12, bottom: 12, trailing: 12)
+        button.configuration = config
+        return button
+    }()
+    private let weekStackView: UIStackView = {
+        let view = UIStackView()
+        
+        view.axis = .horizontal
+        view.distribution = .equalSpacing
+        ["일", "월", "화", "수", "목", "금", "토"].forEach {
+            let label = UILabel()
+            label.text = $0
+            label.font = .bodyM3
+            label.textColor = .gray5
+            label.textAlignment = .center
+            
+            view.addArrangedSubview(label)
+            
+            label.snp.makeConstraints { make in
+                make.width.height.equalTo(40)
+            }
+        }
+        return view
+    }()
+    private let calendarCollectionView: UICollectionView = {
+        let flowLayout = UICollectionViewFlowLayout()
+        flowLayout.minimumLineSpacing = 0
+        flowLayout.minimumInteritemSpacing = 4
+        flowLayout.itemSize = CGSize(width: 40, height: 40)
+        let view = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+        view.isScrollEnabled = false
+        
+        return view
+    }()
+    private let placeCollectionView: UICollectionView = {
+        let flowLayout = UICollectionViewFlowLayout()
+        flowLayout.minimumLineSpacing = 16
+        flowLayout.minimumInteritemSpacing = 0
+        flowLayout.itemSize = CGSize(width: 40, height: 40)
+        flowLayout.sectionInset = UIEdgeInsets.init(top: 0, left: 20, bottom: 0, right: 20)
+        flowLayout.scrollDirection = .horizontal
+        let view = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+        
+        view.isScrollEnabled = true
+        
+        return view
+    }()
+    private let plantCollectionView: UICollectionView = {
+        let flowLayout = UICollectionViewFlowLayout()
+        flowLayout.minimumLineSpacing = 10
+        flowLayout.minimumInteritemSpacing = 0
+        flowLayout.itemSize = CGSize(width: 106, height: 124)
+        flowLayout.sectionInset = UIEdgeInsets.init(top: 0, left: 16, bottom: 0, right: 16)
+        flowLayout.scrollDirection = .horizontal
+        let view = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+        
+        view.isScrollEnabled = true
+        
+        return view
+    }()
+    private let messageView: UIView = {
+        let view = UIView()
+        return view
+    }()
+    private let firstMetView: UIView = {
+        let view = UIView()
+        return view
+    }()
+    private let firstMetLabel: UILabel = {
+        let label = UILabel()
+        label.text = "처음 데려온 날이에요"
+        label.font = .bodyB3
+        return label
+    }()
+    private let waterView: UIView = {
+        let view = UIView()
+        return view
+    }()
+    private let waterLabel: UILabel = {
+        let label = UILabel()
+        label.text = "물 주는 날이에요"
+        label.font = .bodyB3
+        return label
+    }()
+    private let divisionView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .seaGreen
+        return view
+    }()
+    private let memoCollectionView: UICollectionView = {
+        let flowLayout = UICollectionViewFlowLayout()
+        flowLayout.minimumLineSpacing = 0
+        flowLayout.minimumInteritemSpacing = 16
+        flowLayout.sectionInset = UIEdgeInsets.init(top: 0, left: 20, bottom: 16, right: 20)
+        let view = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+        
+        view.isScrollEnabled = false
+        
+        return view
+    }()
+    
+    // MARK: - Life Cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+}

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/CalendarViewController.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/CalendarViewController.swift
@@ -112,22 +112,26 @@ class CalendarViewController: UIViewController {
     }()
     private let firstMetView: UIView = {
         let view = UIView()
+        view.backgroundColor = .sunflowerYellow
         return view
     }()
     private let firstMetLabel: UILabel = {
         let label = UILabel()
         label.text = "처음 데려온 날이에요"
         label.font = .bodyB3
+        label.textColor = .activeOrange
         return label
     }()
     private let waterView: UIView = {
         let view = UIView()
+        view.backgroundColor = .aquaBlue
         return view
     }()
     private let waterLabel: UILabel = {
         let label = UILabel()
         label.text = "물 주는 날이에요"
         label.font = .bodyB3
+        label.textColor = .activeBlue
         return label
     }()
     private let divisionView: UIView = {

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarCollectionViewCell.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarCollectionViewCell.swift
@@ -13,7 +13,7 @@ class CalendarCollectionViewCell: UICollectionViewCell {
     
     let dayLabel: UILabel = {
         let label = UILabel()
-        label.font = .bodyM2
+        label.font = .bodyM1
         label.textColor = .gray6
         label.textAlignment = .center
         return label
@@ -69,6 +69,7 @@ class CalendarCollectionViewCell: UICollectionViewCell {
     }
     
     func setConfigure(with data: String, isSelected: Bool, isToday: Bool) {
+        dayLabel.font = isToday ? .bodyB1 : isSelected ? .bodyB1 : .bodyM1
         dayLabel.text = data
         dayLabel.textColor = isToday ? .seaGreenDark2 : .gray6
         selectedView.isHidden = !isSelected
@@ -86,7 +87,7 @@ class CalendarCollectionViewCell: UICollectionViewCell {
         selectedView.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.centerY.equalToSuperview().inset(1)
-            make.width.height.equalTo(40)
+            make.width.height.equalTo(44)
         }
         
         stackView.snp.makeConstraints { make in

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarCollectionViewCell.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarCollectionViewCell.swift
@@ -1,0 +1,92 @@
+//
+//  CalendarCollectionViewCell.swift
+//  CommonPlant
+//
+//  Created by 아라 on 3/6/24.
+//
+
+import UIKit
+import SnapKit
+
+class CalendarCollectionViewCell: UICollectionViewCell {
+    static let identifier = "CalendarCollectionViewCell"
+    
+    let dayLabel: UILabel = {
+        let label = UILabel()
+        label.font = .bodyM2
+        label.textColor = .gray6
+        label.textAlignment = .center
+        return label
+    }()
+    let selectedView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .seaGreen
+        view.makeRound(radius: 20)
+        view.isHidden = true
+        return view
+    }()
+    let stackView: UIStackView = {
+        let view = UIStackView()
+        view.axis = .horizontal
+        view.distribution = .equalSpacing
+        return view
+    }()
+    let firstMetView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .sunflowerYellow
+        view.makeRound(radius: 2)
+        view.isHidden = true
+        return view
+    }()
+    let waterView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .aquaBlue
+        view.makeRound(radius: 2)
+        view.isHidden = true
+        return view
+    }()
+    let memoView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .seaGreenLight
+        view.makeRound(radius: 2)
+        view.isHidden = true
+        return view
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(\(coder) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        dayLabel.text = nil
+    }
+    
+    func setConstraints() {
+        [selectedView, dayLabel].forEach {
+            contentView.addSubview($0)
+        }
+        
+        dayLabel.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        
+        selectedView.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.centerY.equalToSuperview().inset(1)
+            make.width.height.equalTo(40)
+        }
+        
+        stackView.snp.makeConstraints { make in
+            make.top.equalTo(selectedView.snp.bottom).offset(4)
+            make.centerX.equalToSuperview()
+            make.height.equalTo(4)
+        }
+    }
+}

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarCollectionViewCell.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarCollectionViewCell.swift
@@ -29,6 +29,7 @@ class CalendarCollectionViewCell: UICollectionViewCell {
         let view = UIStackView()
         view.axis = .horizontal
         view.distribution = .equalSpacing
+        view.spacing = 3
         return view
     }()
     let firstMetView: UIView = {
@@ -47,7 +48,7 @@ class CalendarCollectionViewCell: UICollectionViewCell {
     }()
     let memoView: UIView = {
         let view = UIView()
-        view.backgroundColor = .seaGreenLight
+        view.backgroundColor = .mauvePurple
         view.makeRound(radius: 2)
         view.isHidden = true
         return view
@@ -68,6 +69,7 @@ class CalendarCollectionViewCell: UICollectionViewCell {
         dayLabel.text = nil
     }
     
+    // TODO: 동그라미 표시 로직 추가하기
     func setConfigure(with data: String, isSelected: Bool, isToday: Bool) {
         dayLabel.font = isToday ? .bodyB1 : isSelected ? .bodyB1 : .bodyM1
         dayLabel.text = data
@@ -78,6 +80,10 @@ class CalendarCollectionViewCell: UICollectionViewCell {
     func setConstraints() {
         [selectedView, dayLabel, stackView].forEach {
             contentView.addSubview($0)
+        }
+        
+        [firstMetView, waterView, memoView].forEach {
+            stackView.addArrangedSubview($0)
         }
         
         dayLabel.snp.makeConstraints { make in
@@ -91,9 +97,21 @@ class CalendarCollectionViewCell: UICollectionViewCell {
         }
         
         stackView.snp.makeConstraints { make in
-            make.top.equalTo(selectedView.snp.bottom).offset(4)
+            make.bottom.equalTo(selectedView.snp.bottom).offset(-7)
             make.centerX.equalToSuperview()
             make.height.equalTo(4)
+        }
+        
+        waterView.snp.makeConstraints { make in
+            make.width.height.equalTo(4)
+        }
+        
+        firstMetView.snp.makeConstraints { make in
+            make.width.height.equalTo(4)
+        }
+        
+        memoView.snp.makeConstraints { make in
+            make.width.height.equalTo(4)
         }
     }
 }

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarCollectionViewCell.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarCollectionViewCell.swift
@@ -68,8 +68,14 @@ class CalendarCollectionViewCell: UICollectionViewCell {
         dayLabel.text = nil
     }
     
+    func setConfigure(with data: String, isSelected: Bool, isToday: Bool) {
+        dayLabel.text = data
+        dayLabel.textColor = isToday ? .seaGreenDark2 : .gray6
+        selectedView.isHidden = !isSelected
+    }
+    
     func setConstraints() {
-        [selectedView, dayLabel].forEach {
+        [selectedView, dayLabel, stackView].forEach {
             contentView.addSubview($0)
         }
         

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarMemoCollectionViewCell.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarMemoCollectionViewCell.swift
@@ -63,6 +63,17 @@ class CalendarMemoCollectionViewCell: UICollectionViewCell {
         contentLabel.text = nil
     }
     
+    func setConfigure(with data: CalendarMemo) {
+        if let imgUrl = URL(string: data.userProfileImageString) {
+            userImageView.load(url: imgUrl)
+        } else {
+            // TODO: 기본 이미지로
+        }
+        
+        nicknameLabel.text = data.userNickname
+        contentLabel.text = data.content
+    }
+    
     func setConstraints() {
         [userImageView, nicknameLabel, dateLabel, contentLabel, moreLabel].forEach {
             contentView.addSubview($0)

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarMemoCollectionViewCell.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarMemoCollectionViewCell.swift
@@ -16,19 +16,13 @@ class CalendarMemoCollectionViewCell: UICollectionViewCell {
         view.makeRound(radius: 16)
         return view
     }()
-    let nicknameLabel: UILabel = {
+    private let nicknameLabel: UILabel = {
         let label = UILabel()
         label.font = .bodyM2
         label.textColor = .gray6
         return label
     }()
-    let dateLabel: UILabel = {
-        let label = UILabel()
-        label.font = .captionM2
-        label.textColor = .gray4
-        return label
-    }()
-    let contentLabel: UILabel = {
+    private let contentLabel: UILabel = {
         let label = UILabel()
         label.font = .bodyM2
         label.textColor = .gray6
@@ -36,11 +30,10 @@ class CalendarMemoCollectionViewCell: UICollectionViewCell {
         label.lineBreakMode = .byTruncatingTail
         return label
     }()
-    let moreLabel: UILabel = {
-        let label = UILabel()
-        label.font = .captionM1
-        label.textColor = .gray3
-        return label
+    private let nextImageView: UIImageView = {
+        let view = UIImageView()
+        view.image = UIImage(named: "Next")
+        return view
     }()
     
     override init(frame: CGRect) {
@@ -59,8 +52,8 @@ class CalendarMemoCollectionViewCell: UICollectionViewCell {
         
         userImageView.image = nil
         nicknameLabel.text = nil
-        dateLabel.text = nil
         contentLabel.text = nil
+        nextImageView.image = nil
     }
     
     func setConfigure(with data: CalendarMemo) {
@@ -72,10 +65,12 @@ class CalendarMemoCollectionViewCell: UICollectionViewCell {
         
         nicknameLabel.text = data.userNickname
         contentLabel.text = data.content
+        contentLabel.sizeToFit()
+        self.layoutIfNeeded()
     }
     
     func setConstraints() {
-        [userImageView, nicknameLabel, dateLabel, contentLabel, moreLabel].forEach {
+        [userImageView, nicknameLabel, nextImageView, contentLabel].forEach {
             contentView.addSubview($0)
         }
         
@@ -89,20 +84,16 @@ class CalendarMemoCollectionViewCell: UICollectionViewCell {
             make.leading.equalTo(userImageView.snp.trailing).offset(8)
         }
         
-        dateLabel.snp.makeConstraints { make in
+        nextImageView.snp.makeConstraints { make in
             make.centerY.equalTo(userImageView.snp.centerY)
-            make.trailing.equalToSuperview().inset(10)
+            make.trailing.equalToSuperview()
+            make.width.height.equalTo(30)
         }
         
         contentLabel.snp.makeConstraints { make in
             make.top.equalTo(userImageView.snp.bottom).offset(4)
             make.leading.trailing.equalToSuperview().inset(10)
-        }
-        
-        moreLabel.snp.makeConstraints { make in
-            make.top.equalTo(contentLabel.snp.bottom).offset(7)
-            make.trailing.equalToSuperview().inset(10)
-            make.bottom.equalToSuperview().inset(6)
+            make.bottom.equalToSuperview().inset(4)
         }
     }
 }

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarMemoCollectionViewCell.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarMemoCollectionViewCell.swift
@@ -1,0 +1,97 @@
+//
+//  CalendarMemoCollectionViewCell.swift
+//  CommonPlant
+//
+//  Created by 아라 on 3/6/24.
+//
+
+import UIKit
+import SnapKit
+
+class CalendarMemoCollectionViewCell: UICollectionViewCell {
+    static let identifier = "CalendarMemoCollectionViewCell"
+    
+    private let userImageView: UIImageView = {
+        let view = UIImageView()
+        view.makeRound(radius: 16)
+        return view
+    }()
+    let nicknameLabel: UILabel = {
+        let label = UILabel()
+        label.font = .bodyM2
+        label.textColor = .gray6
+        return label
+    }()
+    let dateLabel: UILabel = {
+        let label = UILabel()
+        label.font = .captionM2
+        label.textColor = .gray4
+        return label
+    }()
+    let contentLabel: UILabel = {
+        let label = UILabel()
+        label.font = .bodyM2
+        label.textColor = .gray6
+        label.numberOfLines = 3
+        label.lineBreakMode = .byTruncatingTail
+        return label
+    }()
+    let moreLabel: UILabel = {
+        let label = UILabel()
+        label.font = .captionM1
+        label.textColor = .gray3
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.makeShadow()
+        contentView.makeRound(radius: 10)
+        setConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(\(coder) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        userImageView.image = nil
+        nicknameLabel.text = nil
+        dateLabel.text = nil
+        contentLabel.text = nil
+    }
+    
+    func setConstraints() {
+        [userImageView, nicknameLabel, dateLabel, contentLabel, moreLabel].forEach {
+            contentView.addSubview($0)
+        }
+        
+        userImageView.snp.makeConstraints { make in
+            make.top.leading.equalToSuperview().inset(10)
+            make.width.height.equalTo(32)
+        }
+        
+        nicknameLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(userImageView.snp.centerY)
+            make.leading.equalTo(userImageView.snp.trailing).offset(8)
+        }
+        
+        dateLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(userImageView.snp.centerY)
+            make.trailing.equalToSuperview().inset(10)
+        }
+        
+        contentLabel.snp.makeConstraints { make in
+            make.top.equalTo(userImageView.snp.bottom).offset(4)
+            make.leading.trailing.equalToSuperview().inset(10)
+        }
+        
+        moreLabel.snp.makeConstraints { make in
+            make.top.equalTo(contentLabel.snp.bottom).offset(7)
+            make.trailing.equalToSuperview().inset(10)
+            make.bottom.equalToSuperview().inset(6)
+        }
+    }
+}

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarMemoCollectionViewCell.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarMemoCollectionViewCell.swift
@@ -87,11 +87,11 @@ class CalendarMemoCollectionViewCell: UICollectionViewCell {
         nextImageView.snp.makeConstraints { make in
             make.centerY.equalTo(userImageView.snp.centerY)
             make.trailing.equalToSuperview()
-            make.width.height.equalTo(30)
+            make.width.height.equalTo(48)
         }
         
         contentLabel.snp.makeConstraints { make in
-            make.top.equalTo(userImageView.snp.bottom).offset(4)
+            make.top.equalTo(nextImageView.snp.bottom).offset(4)
             make.leading.trailing.equalToSuperview().inset(10)
             make.bottom.equalToSuperview().inset(4)
         }

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarMemoCollectionViewCell.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarMemoCollectionViewCell.swift
@@ -38,8 +38,9 @@ class CalendarMemoCollectionViewCell: UICollectionViewCell {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        self.makeShadow()
+        contentView.backgroundColor = .white
         contentView.makeRound(radius: 10)
+        self.makeShadow(cornerRadius: 10)
         setConstraints()
     }
     

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarPlaceCollectionViewCell.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarPlaceCollectionViewCell.swift
@@ -61,4 +61,14 @@ class CalendarPlaceCollectionViewCell: UICollectionViewCell {
             make.leading.trailing.equalToSuperview().inset(12)
         }
     }
+    
+    func setSelectedCell() {
+        titleLabel.textColor = .white
+        contentView.backgroundColor = .seaGreenDark2
+    }
+    
+    func setDeselectedCell() {
+        titleLabel.textColor = .seaGreenDark2
+        contentView.backgroundColor = .white
+    }
 }

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarPlaceCollectionViewCell.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarPlaceCollectionViewCell.swift
@@ -1,0 +1,60 @@
+//
+//  PlantCollectionViewCell.swift
+//  CommonPlant
+//
+//  Created by 아라 on 3/6/24.
+//
+
+import UIKit
+import SnapKit
+
+class CalendarPlaceCollectionViewCell: UICollectionViewCell {
+    static let identifier = "CalendarPlaceCollectionViewCell"
+    
+    private let borderView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .clear
+        view.layer.borderColor = UIColor.seaGreenDark2?.cgColor
+        view.layer.borderWidth = 1
+        view.makeRound(radius: 8)
+        return view
+    }()
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .bodyM3
+        label.textColor = .seaGreenDark2
+        label.textAlignment = .center
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        contentView.makeRound(radius: 8)
+        setConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(\(coder) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        titleLabel.text = nil
+    }
+    
+    func setConstraints() {
+        [borderView, titleLabel].forEach {
+            contentView.addSubview($0)
+        }
+        
+        borderView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        
+        titleLabel.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.trailing.equalToSuperview().inset(12)
+        }
+    }
+}

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarPlaceCollectionViewCell.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarPlaceCollectionViewCell.swift
@@ -43,6 +43,10 @@ class CalendarPlaceCollectionViewCell: UICollectionViewCell {
         titleLabel.text = nil
     }
     
+    func setConfigure(whit data: CalendarPlace) {
+        titleLabel.text = data.title
+    }
+    
     func setConstraints() {
         [borderView, titleLabel].forEach {
             contentView.addSubview($0)

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarPlantCollectionViewCell.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarPlantCollectionViewCell.swift
@@ -21,6 +21,7 @@ class CalendarPlantCollectionViewCell: UICollectionViewCell {
         label.font = .bodyM3
         label.textColor = .black
         label.textAlignment = .center
+        label.numberOfLines = 1
         return label
     }()
     private let nameLabel: UILabel = {
@@ -28,6 +29,7 @@ class CalendarPlantCollectionViewCell: UICollectionViewCell {
         label.font = .bodyM3
         label.textColor = .gray5
         label.textAlignment = .center
+        label.numberOfLines = 1
         return label
     }()
     
@@ -84,6 +86,7 @@ class CalendarPlantCollectionViewCell: UICollectionViewCell {
             make.top.equalTo(plantImageView.snp.bottom).offset(6)
             make.centerX.equalToSuperview()
             make.leading.trailing.equalToSuperview().inset(10)
+            make.height.equalTo(20)
         }
         
         nameLabel.snp.makeConstraints { make in
@@ -91,6 +94,7 @@ class CalendarPlantCollectionViewCell: UICollectionViewCell {
             make.centerX.equalToSuperview()
             make.leading.trailing.equalToSuperview().inset(10)
             make.bottom.equalToSuperview().inset(8)
+            make.height.equalTo(20)
         }
     }
     

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarPlantCollectionViewCell.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarPlantCollectionViewCell.swift
@@ -19,7 +19,7 @@ class CalendarPlantCollectionViewCell: UICollectionViewCell {
     private let nicknameLabel: UILabel = {
         let label = UILabel()
         label.font = .bodyM3
-        label.textColor = .gray5
+        label.textColor = .black
         label.textAlignment = .center
         return label
     }()
@@ -33,9 +33,7 @@ class CalendarPlantCollectionViewCell: UICollectionViewCell {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        contentView.backgroundColor = .white
-        contentView.makeRound(radius: 8)
-        self.makeShadow(cornerRadius: 8)
+        setBorder()
         setConstraints()
     }
     
@@ -51,7 +49,13 @@ class CalendarPlantCollectionViewCell: UICollectionViewCell {
         nameLabel.text = nil
     }
     
-    func setConfigure(whit data: CalendarPlant) {
+    func setBorder() {
+        contentView.backgroundColor = .white
+        contentView.makeRound(radius: 8)
+        self.makeShadow(cornerRadius: 8)
+    }
+    
+    func setConfigure(whit data: CalendarPlant, index: Int) {
         if let imgUrl = URL(string: data.imageString) {
             plantImageView.load(url: imgUrl)
         } else {
@@ -60,6 +64,8 @@ class CalendarPlantCollectionViewCell: UICollectionViewCell {
         
         nicknameLabel.text = data.nickname
         nameLabel.text = data.name
+        
+        index > 0 ? setDeselectedCell() : setSelectedCell()
     }
     
     func setConstraints() {
@@ -86,5 +92,13 @@ class CalendarPlantCollectionViewCell: UICollectionViewCell {
             make.leading.trailing.equalToSuperview().inset(10)
             make.bottom.equalToSuperview().inset(8)
         }
+    }
+    
+    func setSelectedCell() {
+        contentView.subviews.map { $0.layer.opacity = 1 }
+    }
+    
+    func setDeselectedCell() {
+        contentView.subviews.map { $0.layer.opacity = 0.5 }
     }
 }

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarPlantCollectionViewCell.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarPlantCollectionViewCell.swift
@@ -50,6 +50,17 @@ class CalendarPlantCollectionViewCell: UICollectionViewCell {
         nameLabel.text = nil
     }
     
+    func setConfigure(whit data: CalendarPlant) {
+        if let imgUrl = URL(string: data.imageString) {
+            plantImageView.load(url: imgUrl)
+        } else {
+            // TODO: 기본 이미지로
+        }
+        
+        nicknameLabel.text = data.nickname
+        nameLabel.text = data.name
+    }
+    
     func setConstraints() {
         [plantImageView, nicknameLabel, nameLabel].forEach {
             contentView.addSubview($0)

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarPlantCollectionViewCell.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarPlantCollectionViewCell.swift
@@ -1,0 +1,78 @@
+//
+//  CalendarPlantCollectionViewCell.swift
+//  CommonPlant
+//
+//  Created by 아라 on 3/6/24.
+//
+
+import UIKit
+import SnapKit
+
+class CalendarPlantCollectionViewCell: UICollectionViewCell {
+    static let identifier = "CalendarPlantCollectionViewCell"
+    
+    private let plantImageView: UIImageView = {
+        let view = UIImageView()
+        view.makeRound(radius: 10)
+        return view
+    }()
+    private let nicknameLabel: UILabel = {
+        let label = UILabel()
+        label.font = .bodyM3
+        label.textColor = .gray5
+        label.textAlignment = .center
+        return label
+    }()
+    private let nameLabel: UILabel = {
+        let label = UILabel()
+        label.font = .bodyM3
+        label.textColor = .gray5
+        label.textAlignment = .center
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.makeShadow()
+        contentView.makeRound(radius: 8)
+        setConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(\(coder) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        plantImageView.image = nil
+        nicknameLabel.text = nil
+        nameLabel.text = nil
+    }
+    
+    func setConstraints() {
+        [plantImageView, nicknameLabel, nameLabel].forEach {
+            contentView.addSubview($0)
+        }
+        
+        plantImageView.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(8)
+            make.centerX.equalToSuperview()
+            make.width.equalTo(83)
+            make.height.equalTo(62)
+        }
+        
+        nicknameLabel.snp.makeConstraints { make in
+            make.top.equalTo(plantImageView.snp.bottom).offset(6)
+            make.centerX.equalToSuperview()
+            make.leading.trailing.equalToSuperview().inset(10)
+        }
+        
+        nameLabel.snp.makeConstraints { make in
+            make.top.equalTo(nicknameLabel.snp.bottom).offset(2)
+            make.centerX.equalToSuperview()
+            make.leading.trailing.equalToSuperview().inset(10)
+            make.bottom.equalToSuperview().inset(8)
+        }
+    }
+}

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarPlantCollectionViewCell.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Cell/CalendarPlantCollectionViewCell.swift
@@ -33,8 +33,9 @@ class CalendarPlantCollectionViewCell: UICollectionViewCell {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        self.makeShadow()
+        contentView.backgroundColor = .white
         contentView.makeRound(radius: 8)
+        self.makeShadow(cornerRadius: 8)
         setConstraints()
     }
     

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
@@ -10,6 +10,10 @@ import SnapKit
 import RxSwift
 import RxRelay
 
+#Preview {
+    CalendarViewController()
+}
+
 class CalendarViewController: UIViewController {
     // MARK: - Properties
     private let viewModel = CalendarViewModel()
@@ -20,7 +24,8 @@ class CalendarViewController: UIViewController {
     // MARK: - UI Components
     private let scrollView: UIView = {
         let view = UIScrollView()
-        view.showsVerticalScrollIndicator = false
+        view.isScrollEnabled = true
+        //view.showsVerticalScrollIndicator = false
         return view
     }()
     private let contentView = UIView()
@@ -103,12 +108,13 @@ class CalendarViewController: UIViewController {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.minimumLineSpacing = 16
         flowLayout.minimumInteritemSpacing = 0
-        flowLayout.itemSize = CGSize(width: 40, height: 40)
+        flowLayout.estimatedItemSize = CGSize(width: 40, height: 40)
         flowLayout.sectionInset = UIEdgeInsets.init(top: 0, left: 20, bottom: 0, right: 20)
         flowLayout.scrollDirection = .horizontal
         let view = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
         view.register(CalendarPlaceCollectionViewCell.self, forCellWithReuseIdentifier: CalendarPlaceCollectionViewCell.identifier)
         view.isScrollEnabled = true
+        view.showsHorizontalScrollIndicator = false
         
         return view
     }()
@@ -122,12 +128,12 @@ class CalendarViewController: UIViewController {
         let view = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
         view.register(CalendarPlantCollectionViewCell.self, forCellWithReuseIdentifier: CalendarPlantCollectionViewCell.identifier)
         view.isScrollEnabled = true
+        view.showsHorizontalScrollIndicator = false
         
         return view
     }()
     private let messageView: UIView = {
         let view = UIView()
-        view.isHidden = true
         return view
     }()
     private let firstMetView: UIView = {
@@ -163,7 +169,8 @@ class CalendarViewController: UIViewController {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.minimumLineSpacing = 0
         flowLayout.minimumInteritemSpacing = 16
-        flowLayout.sectionInset = UIEdgeInsets.init(top: 0, left: 20, bottom: 16, right: 20)
+        flowLayout.sectionInset = UIEdgeInsets.init(top: 0, left: 0, bottom: 16, right: 0)
+        flowLayout.estimatedItemSize = CGSize(width: 300, height: 250)
         let view = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
         view.register(CalendarMemoCollectionViewCell.self, forCellWithReuseIdentifier: CalendarMemoCollectionViewCell.identifier)
         view.isScrollEnabled = false
@@ -316,19 +323,19 @@ class CalendarViewController: UIViewController {
             make.top.equalTo(weekStackView.snp.bottom)
             make.leading.trailing.equalToSuperview().inset(7.5)
             make.bottom.equalToSuperview()
-            make.height.greaterThanOrEqualTo(200)
+            make.height.lessThanOrEqualTo(264).priority(.low)
         }
         
         placeCollectionView.snp.makeConstraints { make in
             make.top.equalTo(calendarView.snp.bottom).offset(10)
             make.leading.trailing.equalToSuperview()
-            make.width.equalTo(40)
+            make.height.equalTo(40)
         }
         
         plantCollectionView.snp.makeConstraints { make in
             make.top.equalTo(placeCollectionView.snp.bottom).offset(21)
             make.leading.trailing.equalToSuperview()
-            make.width.equalTo(124)
+            make.height.equalTo(124)
         }
         
         messageView.snp.makeConstraints { make in
@@ -340,6 +347,7 @@ class CalendarViewController: UIViewController {
         firstMetView.snp.makeConstraints { make in
             make.top.equalToSuperview().inset(7)
             make.leading.equalToSuperview()
+            make.width.height.equalTo(6)
         }
         
         firstMetLabel.snp.makeConstraints { make in
@@ -348,8 +356,10 @@ class CalendarViewController: UIViewController {
         }
         
         waterView.snp.makeConstraints { make in
+            make.top.equalTo(firstMetView.snp.bottom).offset(18)
             make.bottom.equalToSuperview().inset(7)
             make.leading.equalToSuperview()
+            make.width.height.equalTo(6)
         }
         
         waterLabel.snp.makeConstraints { make in

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
@@ -352,8 +352,10 @@ class CalendarViewController: UIViewController {
             datePickerView.isHidden = false
         }.disposed(by: viewModel.disposeBag)
         
-        output.selectedDate.subscribe(onNext: { [weak self] _ in
-            self?.calendarCollectionView.reloadData()
+        output.selectedDate.subscribe(onNext: { [weak self] date in
+            guard let self = self else { return }
+            calendarCollectionView.reloadData()
+            datePicker.date = date
         }).disposed(by: viewModel.disposeBag)
         
         output.showMemoDetail.drive { [weak self] _ in

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
@@ -81,6 +81,16 @@ class CalendarViewController: UIViewController {
         view.register(CalendarCollectionViewCell.self, forCellWithReuseIdentifier: CalendarCollectionViewCell.identifier)
         return view
     }()
+    private let datePicker: UIDatePicker = {
+        let picker = UIDatePicker()
+        picker.datePickerMode = .date
+        picker.preferredDatePickerStyle = .wheels
+        picker.locale = Locale(identifier: "ko_KR")
+        picker.backgroundColor = .seaGreen
+        picker.makeRound(radius: 12)
+        picker.isHidden = true
+        return picker
+    }()
     private let placeCollectionView: UICollectionView = {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.minimumLineSpacing = 16
@@ -169,7 +179,7 @@ class CalendarViewController: UIViewController {
             contentView.addSubview($0)
         }
         
-        [wholeMonthView, previousButton, nextButton, weekStackView, calendarCollectionView].forEach {
+        [wholeMonthView, previousButton, nextButton, weekStackView, calendarCollectionView, datePicker].forEach {
             calendarView.addSubview($0)
         }
         
@@ -203,6 +213,10 @@ class CalendarViewController: UIViewController {
             make.height.equalTo(44)
         }
         
+        datePicker.snp.makeConstraints { make in
+            make.top.equalTo(wholeMonthView.snp.bottom)
+            make.leading.equalToSuperview().offset(14)
+        }
         selectedMonthLabel.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
             make.leading.equalToSuperview().inset(5)

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
@@ -88,7 +88,7 @@ class CalendarViewController: UIViewController {
         flowLayout.sectionInset = UIEdgeInsets.init(top: 0, left: 20, bottom: 0, right: 20)
         flowLayout.scrollDirection = .horizontal
         let view = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
-        
+        view.register(CalendarPlaceCollectionViewCell.self, forCellWithReuseIdentifier: CalendarPlaceCollectionViewCell.identifier)
         view.isScrollEnabled = true
         
         return view

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
@@ -224,6 +224,29 @@ class CalendarViewController: UIViewController {
     }
     
     func bind() {
+        view.rx
+            .tapGesture(configuration: { gestureRecognizer, _ in
+                gestureRecognizer.cancelsTouchesInView = false
+            })
+            .when(.recognized)
+            .subscribe { [weak self] gesture in
+                self?.handleTap(gesture)
+                
+            }.disposed(by: viewModel.disposeBag)
+        
+        cancleButton.rx.tap.subscribe { [weak self] _ in
+            guard let self = self else { return }
+            
+            datePickerView.isHidden = true
+        }.disposed(by: viewModel.disposeBag)
+                                    
+        okButton.rx.tap.subscribe { [weak self] _ in
+            guard let self = self else { return }
+            
+            selectedMonth.accept(datePicker.date)
+            datePickerView.isHidden = true
+        }.disposed(by: viewModel.disposeBag)
+        
         placeCollectionView.rx.itemSelected.subscribe { [weak self] indexPath in
             guard let self = self else { return }
             guard let selectedCell = placeCollectionView.cellForItem(at: indexPath) as? CalendarPlaceCollectionViewCell else { return }
@@ -357,7 +380,7 @@ class CalendarViewController: UIViewController {
             wholeMonthView.addSubview($0)
         }
         
-        [cancleButton, okButton, datePicker].forEach {
+        [datePicker, cancleButton, okButton].forEach {
             datePickerView.addSubview($0)
         }
         
@@ -389,7 +412,7 @@ class CalendarViewController: UIViewController {
         datePickerView.snp.makeConstraints { make in
             make.top.equalTo(wholeMonthView.snp.bottom)
             make.leading.equalToSuperview().offset(14)
-            make.height.equalTo(140)
+            make.height.equalTo(160)
             make.width.equalTo(260)
         }
         
@@ -402,8 +425,8 @@ class CalendarViewController: UIViewController {
         }
         
         datePicker.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(20)
             make.leading.trailing.equalToSuperview().inset(10)
+            make.bottom.equalToSuperview().inset(10)
             make.height.equalTo(116)
             make.width.equalTo(240)
         }
@@ -520,5 +543,14 @@ extension CalendarViewController: UIScrollViewDelegate, UICollectionViewDelegate
         label.sizeToFit()
         
         return label.frame.height
+    }
+    
+    func handleTap(_ gesture: UITapGestureRecognizer) {
+        if datePickerView.isHidden { return }
+        
+        let location = gesture.location(in: datePickerView)
+        if !datePickerView.frame.contains(location) {
+            datePickerView.isHidden = true
+        }
     }
 }

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
@@ -165,16 +165,16 @@ class CalendarViewController: UIViewController {
         view.backgroundColor = .seaGreen
         return view
     }()
-    private let memoCollectionView: UICollectionView = {
+    private lazy var memoCollectionView: UICollectionView = {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.minimumLineSpacing = 0
-        flowLayout.minimumInteritemSpacing = 16
-        flowLayout.sectionInset = UIEdgeInsets.init(top: 0, left: 0, bottom: 16, right: 0)
-        flowLayout.estimatedItemSize = CGSize(width: 300, height: 250)
+        flowLayout.minimumInteritemSpacing = 15
+        flowLayout.sectionInset = UIEdgeInsets.init(top: 0, left: 20, bottom: 16, right: 20)
         let view = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
         view.register(CalendarMemoCollectionViewCell.self, forCellWithReuseIdentifier: CalendarMemoCollectionViewCell.identifier)
         view.isScrollEnabled = false
         
+        view.rx.setDelegate(self).disposed(by: viewModel.disposeBag)
         return view
     }()
     
@@ -375,8 +375,14 @@ class CalendarViewController: UIViewController {
         
         memoCollectionView.snp.makeConstraints { make in
             make.top.equalTo(divisionView.snp.bottom).offset(24)
-            make.leading.trailing.equalToSuperview().inset(20)
+            make.leading.trailing.equalToSuperview()
             make.bottom.equalToSuperview()
         }
     }
+}
+
+extension CalendarViewController: UIScrollViewDelegate, UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: self.view.frame.width - 38, height: collectionView.frame.height)
+        }
 }

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SnapKit
 
 class CalendarViewController: UIViewController {
     // MARK: - UI Components
@@ -17,7 +18,10 @@ class CalendarViewController: UIViewController {
     private let contentView = UIView()
     private let calendarView: UIView = {
         let view = UIView()
-        view.isHidden = true
+        return view
+    }()
+    private let wholeMonthView: UIView = {
+        let view = UIView()
         return view
     }()
     private let selectedMonthLabel: UILabel = {
@@ -26,13 +30,10 @@ class CalendarViewController: UIViewController {
         label.textColor = .gray6
         return label
     }()
-    private let wholeMonthButton: UIButton = {
-        let button = UIButton()
-        var config = UIButton.Configuration.plain()
-        config.image = UIImage(named: "NextMonth")
-        config.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 12, bottom: 12, trailing: 12)
-        button.configuration = config
-        return button
+    private let wholeMonthImageView: UIImageView = {
+        let view = UIImageView()
+        view.image = UIImage(named: "NextMonth")
+        return view
     }()
     private let previousButton: UIButton = {
         let button = UIButton()
@@ -108,6 +109,7 @@ class CalendarViewController: UIViewController {
     }()
     private let messageView: UIView = {
         let view = UIView()
+        view.isHidden = true
         return view
     }()
     private let firstMetView: UIView = {
@@ -154,7 +156,140 @@ class CalendarViewController: UIViewController {
     // MARK: - Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        view.backgroundColor = .white
+        setConstraints()
+    }
+    
+    func setConstraints() {
+        view.addSubview(scrollView)
+        
+        scrollView.addSubview(contentView)
+        
+        [calendarView, placeCollectionView, plantCollectionView, messageView, divisionView, memoCollectionView].forEach {
+            contentView.addSubview($0)
+        }
+        
+        [wholeMonthView, previousButton, nextButton, weekStackView, calendarCollectionView].forEach {
+            calendarView.addSubview($0)
+        }
+        
+        [selectedMonthLabel, wholeMonthImageView].forEach {
+            wholeMonthView.addSubview($0)
+        }
+        
+        [firstMetView, firstMetLabel, waterView, waterLabel].forEach {
+            messageView.addSubview($0)
+        }
+        
+        scrollView.snp.makeConstraints { make in
+            make.top.bottom.equalTo(view.safeAreaLayoutGuide)
+            make.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+        }
+        
+        contentView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+            make.width.equalTo(scrollView.snp.width)
+            make.height.greaterThanOrEqualToSuperview().priority(.low)
+        }
+        
+        calendarView.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(4)
+            make.leading.trailing.equalToSuperview().inset(16)
+        }
+        
+        wholeMonthView.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(8)
+            make.leading.equalToSuperview().offset(11)
+            make.height.equalTo(44)
+        }
+        
+        selectedMonthLabel.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalToSuperview().inset(5)
+        }
+        
+        wholeMonthImageView.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalTo(selectedMonthLabel.snp.trailing).offset(8)
+            make.trailing.equalToSuperview().inset(5)
+            make.width.equalTo(6.98)
+            make.height.equalTo(11.68)
+        }
+        
+        previousButton.snp.makeConstraints { make in
+            make.centerY.equalTo(selectedMonthLabel.snp.centerY)
+            make.trailing.equalTo(nextButton.snp.leading).offset(-6)
+            make.width.height.equalTo(36)
+        }
+        
+        nextButton.snp.makeConstraints { make in
+            make.centerY.equalTo(selectedMonthLabel.snp.centerY)
+            make.trailing.equalToSuperview().inset(7.5)
+            make.width.height.equalTo(36)
+        }
+        
+        weekStackView.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(wholeMonthView.snp.bottom).offset(4)
+            make.leading.trailing.equalToSuperview().inset(7.5)
+            make.height.equalTo(40)
+        }
+        
+        calendarCollectionView.snp.makeConstraints { make in
+            make.top.equalTo(weekStackView.snp.bottom)
+            make.leading.trailing.equalToSuperview().inset(7.5)
+            make.bottom.equalToSuperview()
+            make.height.greaterThanOrEqualTo(200)
+        }
+        
+        placeCollectionView.snp.makeConstraints { make in
+            make.top.equalTo(calendarView.snp.bottom).offset(10)
+            make.leading.trailing.equalToSuperview()
+            make.width.equalTo(40)
+        }
+        
+        plantCollectionView.snp.makeConstraints { make in
+            make.top.equalTo(placeCollectionView.snp.bottom).offset(21)
+            make.leading.trailing.equalToSuperview()
+            make.width.equalTo(124)
+        }
+        
+        messageView.snp.makeConstraints { make in
+            make.top.equalTo(plantCollectionView.snp.bottom).offset(24)
+            make.leading.trailing.equalToSuperview().inset(26)
+            make.height.equalTo(44)
+        }
+        
+        firstMetView.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(7)
+            make.leading.equalToSuperview()
+        }
+        
+        firstMetLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(firstMetView.snp.centerY)
+            make.leading.equalTo(firstMetView.snp.trailing).offset(19)
+        }
+        
+        waterView.snp.makeConstraints { make in
+            make.bottom.equalToSuperview().inset(7)
+            make.leading.equalToSuperview()
+        }
+        
+        waterLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(waterView.snp.centerY)
+            make.leading.equalTo(waterView.snp.trailing).offset(19)
+        }
+        
+        divisionView.snp.makeConstraints { make in
+            make.top.equalTo(messageView.snp.bottom).offset(24)
+            make.leading.trailing.equalToSuperview().inset(16)
+            make.height.equalTo(2)
+        }
+        
+        memoCollectionView.snp.makeConstraints { make in
+            make.top.equalTo(divisionView.snp.bottom).offset(24)
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.bottom.equalToSuperview()
+        }
     }
 }

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
@@ -67,14 +67,14 @@ class CalendarViewController: UIViewController {
         ["일", "월", "화", "수", "목", "금", "토"].forEach {
             let label = UILabel()
             label.text = $0
-            label.font = .bodyM3
+            label.font = .bodyM1
             label.textColor = .gray5
             label.textAlignment = .center
             
             view.addArrangedSubview(label)
             
             label.snp.makeConstraints { make in
-                make.width.height.equalTo(40)
+                make.width.height.equalTo(44)
             }
         }
         return view
@@ -82,8 +82,8 @@ class CalendarViewController: UIViewController {
     private let calendarCollectionView: UICollectionView = {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.minimumLineSpacing = 0
-        flowLayout.minimumInteritemSpacing = 4
-        flowLayout.itemSize = CGSize(width: 40, height: 40)
+        flowLayout.minimumInteritemSpacing = 6
+        flowLayout.itemSize = CGSize(width: 44, height: 44)
         let view = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
         view.isScrollEnabled = false
         view.register(CalendarCollectionViewCell.self, forCellWithReuseIdentifier: CalendarCollectionViewCell.identifier)
@@ -189,7 +189,7 @@ class CalendarViewController: UIViewController {
         viewModel.days.bind(to: calendarCollectionView.rx.items(cellIdentifier: CalendarCollectionViewCell.identifier, cellType: CalendarCollectionViewCell.self)) { [weak self] (_, result, cell) in
             guard let self = self else { return }
             
-            cell.setConfigure(with: result, isSelected: false, isToday: false)
+            cell.setConfigure(with: result, isSelected: viewModel.checkSelectedDay(day: result), isToday: viewModel.checkToday(day: result))
         }.disposed(by: viewModel.disposeBag)
         
         viewModel.placeList.bind(to: placeCollectionView.rx.items(cellIdentifier: CalendarPlaceCollectionViewCell.identifier, cellType: CalendarPlaceCollectionViewCell.self)) { [weak self] (_, result, cell) in
@@ -221,6 +221,10 @@ class CalendarViewController: UIViewController {
             
             datePicker.isHidden = false
         }.disposed(by: viewModel.disposeBag)
+        
+        output.selectedDate.subscribe(onNext: { [weak self] _ in
+            self?.calendarCollectionView.reloadData()
+        }).disposed(by: viewModel.disposeBag)
         
         output.showMemoDetail.drive { [weak self] _ in
             guard let self = self else { return }

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
@@ -11,7 +11,7 @@ import RxSwift
 import RxRelay
 
 #Preview {
-    CalendarViewController()
+    UINavigationController(rootViewController: CalendarViewController())
 }
 
 class CalendarViewController: UIViewController {
@@ -185,8 +185,16 @@ class CalendarViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
+        setNavigationBar()
         bind()
         setConstraints()
+    }
+    
+    func setNavigationBar() {
+        self.navigationController?.isNavigationBarHidden = true
+        let backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: self, action: nil)
+        backBarButtonItem.tintColor = .gray6
+        self.navigationItem.backBarButtonItem = backBarButtonItem
     }
     
     func bind() {
@@ -210,6 +218,13 @@ class CalendarViewController: UIViewController {
             if selectedCell != deselectedCell {
                 deselectedCell.setDeselectedCell()
             }
+        }.disposed(by: viewModel.disposeBag)
+        
+        memoCollectionView.rx.itemSelected.subscribe { [weak self] indexPath in
+            guard let self = self else { return }
+            
+            let nextVC = MemoListViewController(focus: indexPath)
+            self.navigationController?.pushViewController(nextVC, animated: true)
         }.disposed(by: viewModel.disposeBag)
         
         viewModel.currentMonth.subscribe { [weak self] month in

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
@@ -126,7 +126,7 @@ class CalendarViewController: UIViewController {
         flowLayout.minimumLineSpacing = 10
         flowLayout.minimumInteritemSpacing = 0
         flowLayout.itemSize = CGSize(width: 106, height: 124)
-        flowLayout.sectionInset = UIEdgeInsets.init(top: 0, left: 16, bottom: 0, right: 16)
+        flowLayout.sectionInset = UIEdgeInsets.init(top: 21, left: 16, bottom: 24, right: 16)
         flowLayout.scrollDirection = .horizontal
         let view = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
         view.register(CalendarPlantCollectionViewCell.self, forCellWithReuseIdentifier: CalendarPlantCollectionViewCell.identifier)
@@ -172,7 +172,7 @@ class CalendarViewController: UIViewController {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.minimumLineSpacing = 16
         flowLayout.minimumInteritemSpacing = 0
-        flowLayout.sectionInset = UIEdgeInsets.init(top: 0, left: 20, bottom: 16, right: 20)
+        flowLayout.sectionInset = UIEdgeInsets.init(top: 24, left: 20, bottom: 16, right: 20)
         let view = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
         view.register(CalendarMemoCollectionViewCell.self, forCellWithReuseIdentifier: CalendarMemoCollectionViewCell.identifier)
         view.isScrollEnabled = false
@@ -233,6 +233,9 @@ class CalendarViewController: UIViewController {
             .do(onNext: { [weak self] memos in
                 guard let self = self else { return }
                 
+                let topInset: CGFloat = 24
+                let bottomInset: CGFloat = 16
+                
                 var totalHeight: CGFloat = 0.0
                 let contentLabelTop: CGFloat = 52
                 let verticalInset: CGFloat = 20
@@ -245,7 +248,7 @@ class CalendarViewController: UIViewController {
                 }
                 
                 self.memoCollectionView.snp.updateConstraints { make in
-                    make.height.equalTo(totalHeight)
+                    make.height.equalTo(totalHeight + topInset + bottomInset)
                 }
             })
             .bind(to: memoCollectionView.rx.items(cellIdentifier: CalendarMemoCollectionViewCell.identifier, cellType: CalendarMemoCollectionViewCell.self)) { [weak self] (_, result, cell) in
@@ -362,13 +365,13 @@ class CalendarViewController: UIViewController {
         }
         
         plantCollectionView.snp.makeConstraints { make in
-            make.top.equalTo(placeCollectionView.snp.bottom).offset(21)
+            make.top.equalTo(placeCollectionView.snp.bottom)
             make.leading.trailing.equalToSuperview()
-            make.height.equalTo(124)
+            make.height.equalTo(169)
         }
         
         messageView.snp.makeConstraints { make in
-            make.top.equalTo(plantCollectionView.snp.bottom).offset(24)
+            make.top.equalTo(plantCollectionView.snp.bottom)
             make.leading.trailing.equalToSuperview().inset(26)
             make.height.equalTo(44)
         }
@@ -403,7 +406,7 @@ class CalendarViewController: UIViewController {
         }
         
         memoCollectionView.snp.makeConstraints { make in
-            make.top.equalTo(divisionView.snp.bottom).offset(24)
+            make.top.equalTo(divisionView.snp.bottom)
             make.leading.trailing.equalToSuperview()
             make.bottom.equalToSuperview()
         }

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
@@ -17,7 +17,7 @@ import RxRelay
 class CalendarViewController: UIViewController {
     // MARK: - Properties
     private let viewModel = CalendarViewModel()
-    private lazy var input = CalendarViewModel.Input(wholeMonthBtnDidTap: wholeMonthView.rx.tapGesture().map { _ in }.asObservable(), selectedMonth: selectedMonth.asObservable(), previousMonthBtnDidTap: previousButton.rx.tap.asObservable(), nextMonthBtnDidTap: nextButton.rx.tap.asObservable(), selectedDate: calendarCollectionView.rx.itemSelected.asObservable(), selectedPlace: placeCollectionView.rx.itemSelected.asObservable(), selectedPlant: plantCollectionView.rx.itemSelected.asObservable(), selectedMemo: memoCollectionView.rx.itemSelected.asObservable())
+    private lazy var input = CalendarViewModel.Input(wholeMonthBtnDidTap: wholeMonthView.rx.tapGesture().map { _ in }.asObservable(), selectedMonth: selectedMonth.asObservable(), previousMonthBtnDidTap: previousButton.rx.tap.asObservable(), nextMonthBtnDidTap: nextButton.rx.tap.asObservable(), selectedDate: calendarCollectionView.rx.itemSelected.asObservable(), selectedPlace: placeCollectionView.rx.itemSelected.asObservable(), selectedPlant: plantCollectionView.rx.itemSelected.asObservable())
     private lazy var output = viewModel.transform(input: input)
     private lazy var selectedMonth = BehaviorRelay<Date>(value: Date())
     
@@ -242,7 +242,6 @@ class CalendarViewController: UIViewController {
         setNavigationBar()
         bind()
         setConstraints()
-        //checkMessage()
     }
     
     func setNavigationBar() {
@@ -389,12 +388,6 @@ class CalendarViewController: UIViewController {
             calendarCollectionView.reloadData()
             datePicker.date = date
         }).disposed(by: viewModel.disposeBag)
-        
-        output.showMemoDetail.drive { [weak self] _ in
-            guard let self = self else { return }
-            
-            // TODO: 화면 전환 및 해당 메모 포커싱
-        }.disposed(by: viewModel.disposeBag)
     }
     
     func setConstraints() {
@@ -584,6 +577,15 @@ class CalendarViewController: UIViewController {
         }
     }
     
+    func handleTap(_ gesture: UITapGestureRecognizer) {
+        if datePickerView.isHidden { return }
+        
+        let location = gesture.location(in: datePickerView)
+        if !datePickerView.frame.contains(location) {
+            datePickerView.isHidden = true
+        }
+    }
+    
     func checkMessage(_ messages : [String]) {
         firstMetView.isHidden = true
         waterView.isHidden = true
@@ -623,14 +625,5 @@ extension CalendarViewController: UIScrollViewDelegate, UICollectionViewDelegate
         label.sizeToFit()
         
         return label.frame.height
-    }
-    
-    func handleTap(_ gesture: UITapGestureRecognizer) {
-        if datePickerView.isHidden { return }
-        
-        let location = gesture.location(in: datePickerView)
-        if !datePickerView.frame.contains(location) {
-            datePickerView.isHidden = true
-        }
     }
 }

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
@@ -77,7 +77,7 @@ class CalendarViewController: UIViewController {
         flowLayout.itemSize = CGSize(width: 40, height: 40)
         let view = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
         view.isScrollEnabled = false
-        
+        view.register(CalendarCollectionViewCell.self, forCellWithReuseIdentifier: CalendarCollectionViewCell.identifier)
         return view
     }()
     private let placeCollectionView: UICollectionView = {

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
@@ -101,7 +101,7 @@ class CalendarViewController: UIViewController {
         flowLayout.sectionInset = UIEdgeInsets.init(top: 0, left: 16, bottom: 0, right: 16)
         flowLayout.scrollDirection = .horizontal
         let view = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
-        
+        view.register(CalendarPlantCollectionViewCell.self, forCellWithReuseIdentifier: CalendarPlantCollectionViewCell.identifier)
         view.isScrollEnabled = true
         
         return view

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
@@ -292,13 +292,6 @@ class CalendarViewController: UIViewController {
             self?.calendarCollectionView.reloadData()
         }).disposed(by: viewModel.disposeBag)
         
-//        output.deselectedPlace.drive { [weak self] indexPath in
-//            guard let self = self else { return }
-//            guard let cell = placeCollectionView.cellForItem(at: indexPath) as? CalendarPlaceCollectionViewCell else { return }
-//            
-//            cell.setDeselectedCell()
-//        }.disposed(by: viewModel.disposeBag)
-        
         output.showMemoDetail.drive { [weak self] _ in
             guard let self = self else { return }
             

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
@@ -145,7 +145,7 @@ class CalendarViewController: UIViewController {
         flowLayout.minimumInteritemSpacing = 16
         flowLayout.sectionInset = UIEdgeInsets.init(top: 0, left: 20, bottom: 16, right: 20)
         let view = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
-        
+        view.register(CalendarMemoCollectionViewCell.self, forCellWithReuseIdentifier: CalendarMemoCollectionViewCell.identifier)
         view.isScrollEnabled = false
         
         return view

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
@@ -590,6 +590,7 @@ class CalendarViewController: UIViewController {
         firstMetView.isHidden = true
         waterView.isHidden = true
         
+        // TODO: 네트워크 후 수정하기
         for msg in messages {
             switch msg {
             case "처음 데려온 날이에요" :

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
@@ -201,6 +201,17 @@ class CalendarViewController: UIViewController {
             }
         }.disposed(by: viewModel.disposeBag)
         
+        plantCollectionView.rx.itemSelected.subscribe { [weak self] indexPath in
+            guard let self = self else { return }
+            guard let selectedCell = plantCollectionView.cellForItem(at: indexPath) as? CalendarPlantCollectionViewCell else { return }
+            guard let deselectedCell = plantCollectionView.cellForItem(at: viewModel.selectedPlant) as? CalendarPlantCollectionViewCell else { return }
+            
+            selectedCell.setSelectedCell()
+            if selectedCell != deselectedCell {
+                deselectedCell.setDeselectedCell()
+            }
+        }.disposed(by: viewModel.disposeBag)
+        
         viewModel.currentMonth.subscribe { [weak self] month in
             guard let self = self else { return }
             
@@ -231,10 +242,10 @@ class CalendarViewController: UIViewController {
             }
         }.disposed(by: viewModel.disposeBag)
         
-        viewModel.plantList.bind(to: plantCollectionView.rx.items(cellIdentifier: CalendarPlantCollectionViewCell.identifier, cellType: CalendarPlantCollectionViewCell.self)) { [weak self] (_, result, cell) in
+        viewModel.plantList.bind(to: plantCollectionView.rx.items(cellIdentifier: CalendarPlantCollectionViewCell.identifier, cellType: CalendarPlantCollectionViewCell.self)) { [weak self] (row, result, cell) in
             guard let self = self else { return }
             
-            cell.setConfigure(whit: result)
+            cell.setConfigure(whit: result, index: row)
         }.disposed(by: viewModel.disposeBag)
         
         viewModel.messageList.subscribe { [weak self] _ in

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
@@ -97,14 +97,40 @@ class CalendarViewController: UIViewController {
         view.register(CalendarCollectionViewCell.self, forCellWithReuseIdentifier: CalendarCollectionViewCell.identifier)
         return view
     }()
+    private let datePickerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        view.makeRound(radius: 12)
+        view.layer.borderColor = UIColor.seaGreen?.cgColor
+        view.layer.borderWidth = 2
+        view.isHidden = true
+        return view
+    }()
+    private let cancleButton: UIButton = {
+        let button = UIButton()
+        var config = UIButton.Configuration.plain()
+        var attribute = AttributedString.init("취소")
+        attribute.font = .bodyB2
+        config.attributedTitle = attribute
+        config.baseForegroundColor = .gray5
+        button.configuration = config
+        return button
+    }()
+    private let okButton: UIButton = {
+        let button = UIButton()
+        var config = UIButton.Configuration.plain()
+        var attribute = AttributedString.init("확인")
+        attribute.font = .bodyB2
+        config.attributedTitle = attribute
+        config.baseForegroundColor = .seaGreenDark3
+        button.configuration = config
+        return button
+    }()
     private let datePicker: UIDatePicker = {
         let picker = UIDatePicker()
         picker.datePickerMode = .date
         picker.preferredDatePickerStyle = .wheels
         picker.locale = Locale(identifier: "ko_KR")
-        picker.backgroundColor = .seaGreen
-        picker.makeRound(radius: 12)
-        picker.isHidden = true
         return picker
     }()
     private let placeCollectionView: UICollectionView = {
@@ -300,7 +326,7 @@ class CalendarViewController: UIViewController {
         output.showWholeMonth.drive { [weak self] _ in
             guard let self = self else { return }
             
-            datePicker.isHidden = false
+            datePickerView.isHidden = false
         }.disposed(by: viewModel.disposeBag)
         
         output.selectedDate.subscribe(onNext: { [weak self] _ in
@@ -323,12 +349,16 @@ class CalendarViewController: UIViewController {
             contentView.addSubview($0)
         }
         
-        [wholeMonthView, previousButton, nextButton, weekStackView, calendarCollectionView, datePicker].forEach {
+        [wholeMonthView, previousButton, nextButton, weekStackView, calendarCollectionView, datePickerView].forEach {
             calendarView.addSubview($0)
         }
         
         [selectedMonthLabel, wholeMonthImageView].forEach {
             wholeMonthView.addSubview($0)
+        }
+        
+        [cancleButton, okButton, datePicker].forEach {
+            datePickerView.addSubview($0)
         }
         
         [firstMetView, firstMetLabel, waterView, waterLabel].forEach {
@@ -356,10 +386,28 @@ class CalendarViewController: UIViewController {
             make.height.equalTo(44)
         }
         
-        datePicker.snp.makeConstraints { make in
+        datePickerView.snp.makeConstraints { make in
             make.top.equalTo(wholeMonthView.snp.bottom)
             make.leading.equalToSuperview().offset(14)
+            make.height.equalTo(140)
+            make.width.equalTo(260)
         }
+        
+        cancleButton.snp.makeConstraints { make in
+            make.top.leading.equalToSuperview().inset(10)
+        }
+        
+        okButton.snp.makeConstraints { make in
+            make.top.trailing.equalToSuperview().inset(10)
+        }
+        
+        datePicker.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(20)
+            make.leading.trailing.equalToSuperview().inset(10)
+            make.height.equalTo(116)
+            make.width.equalTo(240)
+        }
+        
         selectedMonthLabel.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
             make.leading.equalToSuperview().inset(5)

--- a/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/View/Controller/CalendarViewController.swift
@@ -190,6 +190,17 @@ class CalendarViewController: UIViewController {
     }
     
     func bind() {
+        placeCollectionView.rx.itemSelected.subscribe { [weak self] indexPath in
+            guard let self = self else { return }
+            guard let selectedCell = placeCollectionView.cellForItem(at: indexPath) as? CalendarPlaceCollectionViewCell else { return }
+            guard let deselectedCell = placeCollectionView.cellForItem(at: viewModel.selectedPlace) as? CalendarPlaceCollectionViewCell else { return }
+            
+            selectedCell.setSelectedCell()
+            if selectedCell != deselectedCell {
+                deselectedCell.setDeselectedCell()
+            }
+        }.disposed(by: viewModel.disposeBag)
+        
         viewModel.currentMonth.subscribe { [weak self] month in
             guard let self = self else { return }
             
@@ -211,10 +222,13 @@ class CalendarViewController: UIViewController {
             cell.setConfigure(with: result, isSelected: viewModel.checkSelectedDay(day: result), isToday: viewModel.checkToday(day: result))
         }.disposed(by: viewModel.disposeBag)
         
-        viewModel.placeList.bind(to: placeCollectionView.rx.items(cellIdentifier: CalendarPlaceCollectionViewCell.identifier, cellType: CalendarPlaceCollectionViewCell.self)) { [weak self] (_, result, cell) in
+        viewModel.placeList.bind(to: placeCollectionView.rx.items(cellIdentifier: CalendarPlaceCollectionViewCell.identifier, cellType: CalendarPlaceCollectionViewCell.self)) { [weak self] (row, result, cell) in
             guard let self = self else { return }
             
             cell.setConfigure(whit: result)
+            if row == 0 {
+                cell.setSelectedCell()
+            }
         }.disposed(by: viewModel.disposeBag)
         
         viewModel.plantList.bind(to: plantCollectionView.rx.items(cellIdentifier: CalendarPlantCollectionViewCell.identifier, cellType: CalendarPlantCollectionViewCell.self)) { [weak self] (_, result, cell) in
@@ -266,6 +280,13 @@ class CalendarViewController: UIViewController {
         output.selectedDate.subscribe(onNext: { [weak self] _ in
             self?.calendarCollectionView.reloadData()
         }).disposed(by: viewModel.disposeBag)
+        
+//        output.deselectedPlace.drive { [weak self] indexPath in
+//            guard let self = self else { return }
+//            guard let cell = placeCollectionView.cellForItem(at: indexPath) as? CalendarPlaceCollectionViewCell else { return }
+//            
+//            cell.setDeselectedCell()
+//        }.disposed(by: viewModel.disposeBag)
         
         output.showMemoDetail.drive { [weak self] _ in
             guard let self = self else { return }

--- a/CommonPlant/CommonPlant/Screen/Calendar/ViewModel/CalendarViewModel.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/ViewModel/CalendarViewModel.swift
@@ -99,6 +99,7 @@ extension CalendarViewModel {
             guard let self = self else { return }
             
             calendarDate = date
+            selectedDate = date
             currentMonth.accept(dateToMonthString(calendarDate))
             updateDays()
         }.disposed(by: disposeBag)

--- a/CommonPlant/CommonPlant/Screen/Calendar/ViewModel/CalendarViewModel.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/ViewModel/CalendarViewModel.swift
@@ -23,6 +23,12 @@ class CalendarViewModel {
     let messageList = BehaviorRelay<[String]>(value: [])
     let memoList = BehaviorRelay<[CalendarMemo]>(value: [])
     
+    init() {
+        placeList.accept([CalendarPlace(title: "스윗홈_거실"), CalendarPlace(title: "낫스윗회사_가든"), CalendarPlace(title: "스윗홈_욕실"), CalendarPlace(title: "본가_거실")])
+        plantList.accept([CalendarPlant(imageString: "https://commonplantbucket.s3.ap-northeast-2.amazonaws.com/cf3ab1cb-71e2-4361-bf4d-23078ffd8531..png", nickname: "몬테", name: "몬스테라"),CalendarPlant(imageString: "https://commonplantbucket.s3.ap-northeast-2.amazonaws.com/cf3ab1cb-71e2-4361-bf4d-23078ffd8531..png", nickname: "몬테", name: "몬스테라"),CalendarPlant(imageString: "https://commonplantbucket.s3.ap-northeast-2.amazonaws.com/cf3ab1cb-71e2-4361-bf4d-23078ffd8531..png", nickname: "몬테", name: "몬스테라"),CalendarPlant(imageString: "https://commonplantbucket.s3.ap-northeast-2.amazonaws.com/cf3ab1cb-71e2-4361-bf4d-23078ffd8531..png", nickname: "몬테", name: "몬스테라"),CalendarPlant(imageString: "https://commonplantbucket.s3.ap-northeast-2.amazonaws.com/cf3ab1cb-71e2-4361-bf4d-23078ffd8531..png", nickname: "몬테", name: "몬스테라")])
+        memoList.accept([CalendarMemo(userProfileImageString: "https://commonplantbucket.s3.ap-northeast-2.amazonaws.com/cf3ab1cb-71e2-4361-bf4d-23078ffd8531..png", userNickname: "커먼", content: "잎상태가 매우 좋다 커먼아 앱에서 알려준 물주기의 주기가 아주 딱 맞는 것 같구나. 요즘 내가 물구기 누르는 거 자꾸 깜빡깜빡하니 커먼이 네가 조금 더 신경써주길 바란다."), CalendarMemo(userProfileImageString: "https://commonplantbucket.s3.ap-northeast-2.amazonaws.com/cf3ab1cb-71e2-4361-bf4d-23078ffd8531..png", userNickname: "커먼", content: "잎상태가 매우 좋다 커먼아 앱에서 알려준 물주기의 주기가 아주 딱 맞는 것 같구나. 요즘 내가 물구기 누르는 거 자꾸 깜빡깜빡하니 커먼이 네가 조금 더 신경써주길 바란다."), CalendarMemo(userProfileImageString: "https://commonplantbucket.s3.ap-northeast-2.amazonaws.com/cf3ab1cb-71e2-4361-bf4d-23078ffd8531..png", userNickname: "커먼", content: "잎상태가 매우 좋다 커먼아 앱에서 알려준 물주기의 주기가 아주 딱 맞는 것 같구나. 요즘 내가 물구기 누르는 거 자꾸 깜빡깜빡하니 커먼이 네가 조금 더 신경써주길 바란다."),CalendarMemo(userProfileImageString: "https://commonplantbucket.s3.ap-northeast-2.amazonaws.com/cf3ab1cb-71e2-4361-bf4d-23078ffd8531..png", userNickname: "커먼", content: "잎상태가 매우 좋다 커먼아 앱에서 알려준 물주기의 주기가 아주 딱 맞는 것 같구나. 요즘 내가 물구기 누르는 거 자꾸 깜빡깜빡하니 커먼이 네가 조금 더 신경써주길 바란다.")])
+    }
+    
     func dateToMonthString(_ date: Date) -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy년 M월"

--- a/CommonPlant/CommonPlant/Screen/Calendar/ViewModel/CalendarViewModel.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/ViewModel/CalendarViewModel.swift
@@ -40,6 +40,26 @@ class CalendarViewModel {
         
         self.days.accept(empty + days)
     }
+    
+    func checkToday(day: String) -> Bool {
+        guard let day = Int(day) else { return false }
+        guard let newDate = calendar.date(bySetting: .day, value: day, of: calendarDate) else { return false }
+        
+        let todayComponents = calendar.dateComponents([.year, .month, .day], from: todayDate)
+        let newDateComponents = calendar.dateComponents([.year, .month, .day], from: newDate)
+        
+        return todayComponents == newDateComponents
+    }
+    
+    func checkSelectedDay(day: String) -> Bool {
+        guard let day = Int(day) else { return false }
+        guard let newDate = calendar.date(bySetting: .day, value: day, of: calendarDate) else { return false }
+        
+        let selectedComponents = calendar.dateComponents([.year, .month, .day], from: selectedDate)
+        let newDateComponents = calendar.dateComponents([.year, .month, .day], from: newDate)
+        
+        return selectedComponents == newDateComponents
+    }
 }
 
 extension CalendarViewModel {
@@ -56,6 +76,7 @@ extension CalendarViewModel {
     
     struct Output {
         let showWholeMonth: Driver<Void>
+        let selectedDate: Observable<Void>
         let showMemoDetail: Driver<IndexPath>
     }
     
@@ -91,7 +112,7 @@ extension CalendarViewModel {
                 updateDays()
             }.disposed(by: disposeBag)
         
-        let selectDate = PublishRelay<IndexPath>()
+        let selectDate = PublishRelay<Void>()
         input.selectedDate.bind { [weak self] index in
             guard let self = self else { return }
             guard let newDay = Int(days.value[index.row]) else { return }
@@ -101,7 +122,7 @@ extension CalendarViewModel {
             
             guard let newDate = calendar.date(from: dateComponents) else { return }
             
-            selectDate.accept(index)
+            selectDate.accept(())
             selectedDate = newDate
         }.disposed(by: disposeBag)
         
@@ -126,6 +147,7 @@ extension CalendarViewModel {
         }.disposed(by: disposeBag)
         
         return Output(showWholeMonth: showWholeMonth.asDriver(onErrorJustReturn: ()),
+                      selectedDate: selectDate.asObservable(),
                       showMemoDetail: showMemoDetail.asDriver(onErrorDriveWith: .empty()))
     }
 }

--- a/CommonPlant/CommonPlant/Screen/Calendar/ViewModel/CalendarViewModel.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/ViewModel/CalendarViewModel.swift
@@ -82,13 +82,11 @@ extension CalendarViewModel {
         let selectedDate: Observable<IndexPath>
         let selectedPlace: Observable<IndexPath>
         let selectedPlant: Observable<IndexPath>
-        let selectedMemo: Observable<IndexPath>
     }
     
     struct Output {
         let showWholeMonth: Driver<Void>
         let selectedDate: Observable<Date>
-        let showMemoDetail: Driver<IndexPath>
     }
     
     func transform(input: Input) -> Output {
@@ -154,15 +152,7 @@ extension CalendarViewModel {
             selectedPlant = indexPath
         }.disposed(by: disposeBag)
         
-        let showMemoDetail = PublishRelay<IndexPath>()
-        input.selectedMemo.subscribe { [weak self] indexPath in
-            guard let self = self else { return }
-            
-            showMemoDetail.accept(indexPath)
-        }.disposed(by: disposeBag)
-        
         return Output(showWholeMonth: showWholeMonth.asDriver(onErrorJustReturn: ()),
-                      selectedDate: selectDate.asObservable(),
-                      showMemoDetail: showMemoDetail.asDriver(onErrorDriveWith: .empty()))
+                      selectedDate: selectDate.asObservable())
     }
 }

--- a/CommonPlant/CommonPlant/Screen/Calendar/ViewModel/CalendarViewModel.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/ViewModel/CalendarViewModel.swift
@@ -59,10 +59,13 @@ class CalendarViewModel {
     
     func checkSelectedDay(day: String) -> Bool {
         guard let day = Int(day) else { return false }
-        guard let newDate = calendar.date(bySetting: .day, value: day, of: calendarDate) else { return false }
+        var components = Calendar.current.dateComponents([.year, .month, .timeZone], from: calendarDate)
+        components.day = day
+        
+        guard let newDate = Calendar.current.date(from: components) else { return false }
+        let newDateComponents = calendar.dateComponents([.year, .month, .day], from: newDate)
         
         let selectedComponents = calendar.dateComponents([.year, .month, .day], from: selectedDate)
-        let newDateComponents = calendar.dateComponents([.year, .month, .day], from: newDate)
         
         return selectedComponents == newDateComponents
     }

--- a/CommonPlant/CommonPlant/Screen/Calendar/ViewModel/CalendarViewModel.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/ViewModel/CalendarViewModel.swift
@@ -87,12 +87,14 @@ extension CalendarViewModel {
     
     struct Output {
         let showWholeMonth: Driver<Void>
-        let selectedDate: Observable<Void>
+        let selectedDate: Observable<Date>
         let showMemoDetail: Driver<IndexPath>
     }
     
     func transform(input: Input) -> Output {
         let showWholeMonth = PublishRelay<Void>()
+        let selectDate = PublishRelay<Date>()
+        
         input.wholeMonthBtnDidTap.bind(to: showWholeMonth).disposed(by: disposeBag)
         
         input.selectedMonth.subscribe { [ weak self ] date in
@@ -100,6 +102,7 @@ extension CalendarViewModel {
             
             calendarDate = date
             selectedDate = date
+            selectDate.accept(date)
             currentMonth.accept(dateToMonthString(calendarDate))
             updateDays()
         }.disposed(by: disposeBag)
@@ -124,7 +127,6 @@ extension CalendarViewModel {
                 updateDays()
             }.disposed(by: disposeBag)
         
-        let selectDate = PublishRelay<Void>()
         input.selectedDate.bind { [weak self] index in
             guard let self = self else { return }
             guard let newDay = Int(days.value[index.row]) else { return }
@@ -134,7 +136,7 @@ extension CalendarViewModel {
             
             guard let newDate = calendar.date(from: dateComponents) else { return }
             
-            selectDate.accept(())
+            selectDate.accept(newDate)
             selectedDate = newDate
         }.disposed(by: disposeBag)
         

--- a/CommonPlant/CommonPlant/Screen/Calendar/ViewModel/CalendarViewModel.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/ViewModel/CalendarViewModel.swift
@@ -15,6 +15,7 @@ class CalendarViewModel {
     let todayDate = Date()
     var selectedDate = Date()
     var calendarDate = Date()
+    var selectedPlace: IndexPath = [0, 0]
     
     let currentMonth = BehaviorRelay<String>(value: "")
     let days = BehaviorRelay<[String]>(value: [])
@@ -140,6 +141,7 @@ extension CalendarViewModel {
             
             // TODO: 식물 리스트 업데이트
             // TODO: 첫번째 식물을 기준으로 메세지와 메모 리스트 업데이트
+            selectedPlace = indexPath
         }.disposed(by: disposeBag)
 
         input.selectedPlant.subscribe { [weak self] indexPath in

--- a/CommonPlant/CommonPlant/Screen/Calendar/ViewModel/CalendarViewModel.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/ViewModel/CalendarViewModel.swift
@@ -1,0 +1,131 @@
+//
+//  CalendarViewModel.swift
+//  CommonPlant
+//
+//  Created by 아라 on 3/6/24.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+class CalendarViewModel {
+    let disposeBag = DisposeBag()
+    let calendar = Calendar.current
+    let todayDate = Date()
+    var selectedDate = Date()
+    var calendarDate = Date()
+    
+    let currentMonth = BehaviorRelay<String>(value: "")
+    let days = BehaviorRelay<[String]>(value: [])
+    let placeList = BehaviorRelay<[Place]>(value: [])
+    let plantList = BehaviorRelay<[Plant]>(value: [])
+    let messageList = BehaviorRelay<[String]>(value: [])
+    let memoList = BehaviorRelay<[Memo]>(value: [])
+    
+    func dateToMonthString(_ date: Date) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy년 M월"
+        
+        return dateFormatter.string(from: date)
+    }
+    
+    func updateDays() {
+        let dateComponents = calendar.dateComponents([.year, .month], from: calendarDate)
+        guard let firstDayOfMonth = calendar.date(from: dateComponents) else { return }
+        let weekdayOfFirstDay = calendar.component(.weekday, from: firstDayOfMonth)
+        guard let numberOfDays = calendar.range(of: .day, in: .month, for: calendarDate)?.count else { return }
+        let empty = Array(repeating: "", count: weekdayOfFirstDay - 1)
+        let days = (1...numberOfDays).map { String($0) }
+        
+        self.days.accept(empty + days)
+    }
+}
+
+extension CalendarViewModel {
+    struct Input {
+        let wholeMonthBtnDidTap: Observable<Void>
+        let selectedMonth: Observable<Date>
+        let previousMonthBtnDidTap: Observable<Void>
+        let nextMonthBtnDidTap: Observable<Void>
+        let selectedDate: Observable<IndexPath>
+        let selectedPlace: Observable<IndexPath>
+        let selectedPlant: Observable<IndexPath>
+        let selectedMemo: Observable<IndexPath>
+    }
+    
+    struct Output {
+        let showWholeMonth: Driver<Void>
+        let showMemoDetail: Driver<IndexPath>
+    }
+    
+    func transform(input: Input) -> Output {
+        let showWholeMonth = BehaviorRelay<Void>(value: ())
+        input.wholeMonthBtnDidTap.bind(to: showWholeMonth).disposed(by: disposeBag)
+        
+        input.selectedMonth.subscribe { [ weak self ] date in
+            guard let self = self else { return }
+            
+            calendarDate = date
+            currentMonth.accept(dateToMonthString(calendarDate))
+            updateDays()
+        }.disposed(by: disposeBag)
+        
+        input.previousMonthBtnDidTap
+            .bind { [weak self] () in
+                guard let self = self else { return }
+                guard let preMonthDate = calendar.date(byAdding: .month, value: -1, to: calendarDate) else { return }
+                
+                calendarDate = preMonthDate
+                currentMonth.accept(dateToMonthString(calendarDate))
+                updateDays()
+            }.disposed(by: disposeBag)
+        
+        input.nextMonthBtnDidTap
+            .bind { [weak self] () in
+                guard let self = self else { return }
+                guard let nextMonthDate = calendar.date(byAdding: .month, value: 1, to: calendarDate) else { return }
+                
+                calendarDate = nextMonthDate
+                currentMonth.accept(dateToMonthString(calendarDate))
+                updateDays()
+            }.disposed(by: disposeBag)
+        
+        let selectDate = PublishRelay<IndexPath>()
+        input.selectedDate.bind { [weak self] index in
+            guard let self = self else { return }
+            guard let newDay = Int(days.value[index.row]) else { return }
+            
+            var dateComponents = calendar.dateComponents([.year, .month], from: calendarDate)
+            dateComponents.day = newDay
+            
+            guard let newDate = calendar.date(from: dateComponents) else { return }
+            
+            selectDate.accept(index)
+            selectedDate = newDate
+        }.disposed(by: disposeBag)
+        
+        input.selectedPlace.subscribe { [weak self] indexPath in
+            guard let self = self else { return }
+            
+            // TODO: 식물 리스트 업데이트
+            // TODO: 첫번째 식물을 기준으로 메세지와 메모 리스트 업데이트
+        }.disposed(by: disposeBag)
+
+        input.selectedPlant.subscribe { [weak self] indexPath in
+            guard let self = self else { return }
+            
+            // TODO: 메세지와 메모 리스트 업데이트
+        }.disposed(by: disposeBag)
+        
+        let showMemoDetail = PublishRelay<IndexPath>()
+        input.selectedMemo.subscribe { [weak self] indexPath in
+            guard let self = self else { return }
+            
+            showMemoDetail.accept(indexPath)
+        }.disposed(by: disposeBag)
+        
+        return Output(showWholeMonth: showWholeMonth.asDriver(onErrorJustReturn: ()),
+                      showMemoDetail: showMemoDetail.asDriver(onErrorDriveWith: .empty()))
+    }
+}

--- a/CommonPlant/CommonPlant/Screen/Calendar/ViewModel/CalendarViewModel.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/ViewModel/CalendarViewModel.swift
@@ -18,10 +18,10 @@ class CalendarViewModel {
     
     let currentMonth = BehaviorRelay<String>(value: "")
     let days = BehaviorRelay<[String]>(value: [])
-    let placeList = BehaviorRelay<[Place]>(value: [])
-    let plantList = BehaviorRelay<[Plant]>(value: [])
+    let placeList = BehaviorRelay<[CalendarPlace]>(value: [])
+    let plantList = BehaviorRelay<[CalendarPlant]>(value: [])
     let messageList = BehaviorRelay<[String]>(value: [])
-    let memoList = BehaviorRelay<[Memo]>(value: [])
+    let memoList = BehaviorRelay<[CalendarMemo]>(value: [])
     
     func dateToMonthString(_ date: Date) -> String {
         let dateFormatter = DateFormatter()

--- a/CommonPlant/CommonPlant/Screen/Calendar/ViewModel/CalendarViewModel.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/ViewModel/CalendarViewModel.swift
@@ -81,7 +81,7 @@ extension CalendarViewModel {
     }
     
     func transform(input: Input) -> Output {
-        let showWholeMonth = BehaviorRelay<Void>(value: ())
+        let showWholeMonth = PublishRelay<Void>()
         input.wholeMonthBtnDidTap.bind(to: showWholeMonth).disposed(by: disposeBag)
         
         input.selectedMonth.subscribe { [ weak self ] date in

--- a/CommonPlant/CommonPlant/Screen/Calendar/ViewModel/CalendarViewModel.swift
+++ b/CommonPlant/CommonPlant/Screen/Calendar/ViewModel/CalendarViewModel.swift
@@ -16,6 +16,7 @@ class CalendarViewModel {
     var selectedDate = Date()
     var calendarDate = Date()
     var selectedPlace: IndexPath = [0, 0]
+    var selectedPlant: IndexPath = [0, 0]
     
     let currentMonth = BehaviorRelay<String>(value: "")
     let days = BehaviorRelay<[String]>(value: [])
@@ -147,7 +148,7 @@ extension CalendarViewModel {
         input.selectedPlant.subscribe { [weak self] indexPath in
             guard let self = self else { return }
             
-            // TODO: 메세지와 메모 리스트 업데이트
+            selectedPlant = indexPath
         }.disposed(by: disposeBag)
         
         let showMemoDetail = PublishRelay<IndexPath>()

--- a/CommonPlant/CommonPlant/Screen/Main/ViewController/MainTabBarController.swift
+++ b/CommonPlant/CommonPlant/Screen/Main/ViewController/MainTabBarController.swift
@@ -42,7 +42,7 @@ class MainTabBarController: UITabBarController {
     private func configureUI() {
         tabBar.backgroundColor = .white
         let plantSearchViewController = UINavigationController(rootViewController: PlantSearchViewController())
-        let calenderViewController = CalendarViewController()
+        let calenderViewController = UINavigationController(rootViewController: CalendarViewController())
         let mainViewController = UINavigationController(rootViewController: MainViewController())
         let profileViewController = MyPageViewController()
         

--- a/CommonPlant/CommonPlant/Screen/Main/ViewController/MainTabBarController.swift
+++ b/CommonPlant/CommonPlant/Screen/Main/ViewController/MainTabBarController.swift
@@ -42,7 +42,7 @@ class MainTabBarController: UITabBarController {
     private func configureUI() {
         tabBar.backgroundColor = .white
         let plantSearchViewController = UINavigationController(rootViewController: PlantSearchViewController())
-        let calenderViewController = PlantSearchViewController()
+        let calenderViewController = CalendarViewController()
         let mainViewController = UINavigationController(rootViewController: MainViewController())
         let profileViewController = MyPageViewController()
         

--- a/CommonPlant/CommonPlant/Screen/MyPlant/View/MemoCardCollectionViewCell.swift
+++ b/CommonPlant/CommonPlant/Screen/MyPlant/View/MemoCardCollectionViewCell.swift
@@ -33,7 +33,7 @@ class MemoCardCollectionViewCell: UICollectionViewCell {
     
     // MARK: Custom Methods
     func setAttributes() {
-        self.makeShadow()
+        self.makeShadow(cornerRadius: 16)
         self.backgroundColor = .white
         
         memoCardView.makeRound(radius: 16)

--- a/CommonPlant/CommonPlant/Screen/MyPlant/View/MemoListViewController.swift
+++ b/CommonPlant/CommonPlant/Screen/MyPlant/View/MemoListViewController.swift
@@ -14,6 +14,7 @@ class MemoListViewController: UIViewController {
     // MARK: - Properties
     var viewModel = MemoViewModel()
     let identifier = MemoCollectionViewCell.identifier
+    var initialFocus: IndexPath
     
     // MARK: - UI Components
     var backgroundView = UIView()
@@ -34,6 +35,18 @@ class MemoListViewController: UIViewController {
         
         view.backgroundColor = .clear
         
+        return view
+    }()
+    let editLabel: UILabel = {
+        let label = UILabel()
+        label.text = "작성하기"
+        label.font = .bodyM3
+        label.textColor = .seaGreenDark2
+        return label
+    }()
+    let editView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .red
         return view
     }()
     
@@ -60,13 +73,40 @@ class MemoListViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
-        
+        setNavigationBar()
         setAttributes()
         setConstraints()
         bind()
     }
     
+    init(focus: IndexPath) {
+        initialFocus = focus
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        // TODO: 네트워킹 후 식물 id 값으로 포커스 잡기
+        memoCollectionView.scrollToItem(at: initialFocus, at: .top, animated: true)
+    }
+    
     // MARK: - Custom Methods
+    func setNavigationBar() {
+        self.navigationController?.isNavigationBarHidden = false
+        self.navigationController?.navigationBar.shadowImage = UIImage()
+        
+        self.navigationItem.title = "Memo"
+        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.bodyB1, .foregroundColor: UIColor.gray6 as Any]
+        
+        let rightBarItem = UIBarButtonItem(customView: editLabel)
+        self.navigationItem.rightBarButtonItem = rightBarItem
+    }
+    
     func setAttributes() {
         backgroundView.backgroundColor = .black
         backgroundView.layer.opacity = 0.7


### PR DESCRIPTION
## 🚀관련 이슈
- close #30 

## ✨작업 내용
- 커스텀 캘린더 구현
- #22 에서 언급한 그림자 렌더링 이슈 해결
- 메모 선택 시 메모View의 특정 index 메모 포커스

## 📸 스크린샷
<img  width="40%" src="https://github.com/UMC-CommonPlant/CommonPlant-iOS-refactoring/assets/52594310/343f9863-b5fa-419c-b58b-76bf2a4ff162"/>

## 📝참고 사항
- 식물 추가할 때 사용한 캘린더뷰를 활용해서 공용으로 사용하고싶었으나!!! 일단 그냥 따로 구현한 상태
- 처음 데려온 날, 물 주는 날, 메모 유무 표시는 UI는 잡아뒀고 API 완성되면 맞춰서 수정할 예정
- 날짜 선택시, 특정 상황에서 선택 표시가 원하는대로 안되는 문제 있었음 -> 선택한 Date값을 세팅하는 방식을 변경하여 해결